### PR TITLE
BUG: updating rust

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -11,14 +11,17 @@ RUN rm -rf /root/sgx
 RUN apt-get update && \
     apt-get install -y --no-install-recommends libzmq3-dev clang \
     && rm -rf /var/lib/apt/lists/*
+    
+# fixes build errors that started appearing seemingly out of nowhere in dependencies:
+# error[E0658]: const fn is unstable (see issue #53555)      
+RUN rustup install nightly-2018-11-01
+RUN rustup default nightly-2018-11-01
 
 RUN /root/.cargo/bin/rustup target add wasm32-unknown-unknown && \
     rm -rf /root/.cargo/registry && rm -rf /root/.cargo/git
 
-
 # clone the rust-sgx-sdk baidu sdk v1.0.4
 RUN git clone --depth 1  -b v1.0.4 https://github.com/baidu/rust-sgx-sdk.git  sgx
-
 
 RUN git clone --depth 1 --branch v5.14.2 https://github.com/facebook/rocksdb.git rocksdb && \
     cd rocksdb && make install-shared && rm -rf /root/rocksdb


### PR DESCRIPTION
Today @fredfortier reported build errors appearing seemingly out of the blue from a dependency, that we checked were system independent but related to an older version of rust that this image was running. If we updated to a much newer version other errors would appear, so "locking" Rust to this version `nightly-2018-11-01` fixed these build errors.

For the record, this is a failed build before this fix:
```
~/src/enigma-core# make JOBS=1 DEBUG=1
mkdir -p ./lib
make -C ./enclave/ CARGO_FLAGS=-j1 Rust_target_dir=debug
make[1]: Entering directory '/root/src/enigma-core/enclave'
cargo build -j1
    Updating git repository `https://github.com/enigmampc/error-chain.git`
    Updating crates.io index                                                                                                                                                                                     
    Updating git repository `https://github.com/enigmampc/ethabi.git`                                                                                                                                            
    Updating git repository `https://github.com/enigmampc/json-patch.git`                                                                                                                                        
    Updating git repository `https://github.com/enigmampc/parity-wasm.git`                                                                                                                                       
    Updating git repository `https://github.com/enigmampc/wasm-utils.git`                                                                                                                                        
    Updating git repository `https://github.com/enigmampc/rustc-hex.git`                                                                                                                                         
    Updating git repository `https://github.com/baidu/rust-sgx-sdk.git`                                                                                                                                          
    Updating git repository `https://github.com/enigmampc/sputnikvm.git`                                                                                                                                         
    Updating git repository `https://github.com/enigmampc/wasmi`                                                                                                                                                 
    Updating git repository `https://github.com/elichai/ring.git`                                                                                                                                                
    Updating git repository `https://github.com/enigmampc/msgpack-rust.git`                                                                                                                                      
    Updating git repository `https://github.com/enigmampc/treediff-rs.git`                                                                                                                                       
    Updating git repository `https://github.com/enigmampc/primitives.git`                                                                                                                                        
   Compiling proc-macro2 v0.4.27                                                                                                                                                                                 
   Compiling unicode-xid v0.1.0                                                                                                                                                                                  
   Compiling autocfg v0.1.2                                                                                                                                                                                      
   Compiling libc v0.2.49                                                                                                                                                                                        
   Compiling rand_core v0.4.0                                                                                                                                                                                    
   Compiling typenum v1.10.0                                                                                                                                                                                     
   Compiling ryu v0.2.7                                                                                                                                                                                          
   Compiling serde v1.0.88                                                                                                                                                                                       
   Compiling unicode-width v0.1.5                                                                                                                                                                                
   Compiling sgx_build_helper v0.1.0 (https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.4#212d9f4b)                                                                                                             
   Compiling sgx_unwind v0.0.1 (https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.4#212d9f4b)                                                                                                                   
   Compiling sgx_types v1.0.4 (https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.4#212d9f4b)                                                                                                                    
   Compiling strsim v0.7.0                                                                                                                                                                                       
   Compiling ansi_term v0.11.0                                                                                                                                                                                   
   Compiling vec_map v0.8.1                                                                                                                                                                                      
   Compiling remove_dir_all v0.5.1                                                                                                                                                                               
   Compiling nodrop v0.1.13                                                                                                                                                                                      
   Compiling bitflags v1.0.4                                                                                                                                                                                     
   Compiling cfg-if v0.1.6                                                                                                                                                                                       
   Compiling itoa v0.4.3                                                                                                                                                                                         
   Compiling byteorder v1.3.1                                                                                                                                                                                    
   Compiling constant_time_eq v0.1.3                                                                                                                                                                             
   Compiling serde v1.0.71 (https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.4#212d9f4b)                                                                                                                       
   Compiling failure_derive v0.1.5                                                                                                                                                                               
   Compiling byte-tools v0.2.0                                                                                                                                                                                   
   Compiling cc v1.0.29                                                                                                                                                                                          
   Compiling byte-tools v0.3.1                                                                                                                                                                                   
   Compiling arrayvec v0.4.10                                                                                                                                                                                    
   Compiling crunchy v0.1.6                                                                                                                                                                                      
   Compiling spin v0.5.0                                                                                                                                                                                         
error[E0658]: const fn is unstable (see issue #53555)                                                                                                                                                            
   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.5.0/src/mutex.rs:109:5                                                                                                                       
    |                                                                                                                                                                                                            
109 | /     pub const fn new(user_data: T) -> Mutex<T>                                                                                                                                                           
110 | |     {                                                                                                                                                                                                    
111 | |         Mutex                                                                                                                                                                                            
112 | |         {                                                                                                                                                                                                
...   |                                                                                                                                                                                                          
115 | |         }                                                                                                                                                                                                
116 | |     }                                                                                                                                                                                                    
    | |_____^                                                                                                                                                                                                    
    |                                                                                                                                                                                                            
    = help: add #![feature(min_const_fn)] to the crate attributes to enable                                                                                                                                      
                                                                                                                                                                                                                 
error[E0658]: const fn is unstable (see issue #53555)                                                                                                                                                            
   --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.5.0/src/rw_lock.rs:96:5                                                                                                                      
    |                                                                                                                                                                                                            
96  | /     pub const fn new(user_data: T) -> RwLock<T>                                                                                                                                                          
97  | |     {                                                                                                                                                                                                    
98  | |         RwLock                                                                                                                                                                                           
99  | |         {                                                                                                                                                                                                
...   |                                                                                                                                                                                                          
102 | |         }                                                                                                                                                                                                
103 | |     }                                                                                                                                                                                                    
    | |_____^                                                                                                                                                                                                    
    |                                                                                                                                                                                                            
    = help: add #![feature(min_const_fn)] to the crate attributes to enable                                                                                                                                      
                                                                                                                                                                                                                 
error[E0658]: const fn is unstable (see issue #53555)                                                                                                                                                            
  --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/spin-0.5.0/src/once.rs:59:5                                                                                                                          
   |                                                                                                                                                                                                             
59 | /     pub const fn new() -> Once<T> {                                                                                                                                                                       
60 | |         Self::INIT                                                                                                                                                                                        
61 | |     }                                                                                                                                                                                                     
   | |_____^                                                                                                                                                                                                     
   |                                                                                                                                                                                                             
   = help: add #![feature(min_const_fn)] to the crate attributes to enable                                                                                                                                       
                                                                                                                                                                                                                 
error: aborting due to 3 previous errors                                                                                                                                                                         
                                                                                                                                                                                                                 
For more information about this error, try `rustc --explain E0658`.                                                                                                                                              
error: Could not compile `spin`.                                                                                                                                                                                 

To learn more, run the command again with --verbose.
Makefile:14: recipe for target 'libenclave.a' failed
make[1]: *** [libenclave.a] Error 101
make[1]: Leaving directory '/root/src/enigma-core/enclave'
Makefile:143: recipe for target 'enclave' failed
make: *** [enclave] Error 2
          
```