### PR TITLE
GetPTTRequest used bad object structure

### DIFF
--- a/enigma-core/app/src/networking/messages.rs
+++ b/enigma-core/app/src/networking/messages.rs
@@ -164,13 +164,14 @@ pub struct PrincipalResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Addresses (pub Vec<String>);
+pub struct Addresses {
+    pub addresses: Vec<String>,
+}
 
 impl std::ops::Deref for Addresses {
     type Target = Vec<String>;
     fn deref(&self) -> &Vec<String> {
-        &self.0
+        &self.addresses
     }
 }
 

--- a/enigma-core/app/tests/integration_utils.rs
+++ b/enigma-core/app/tests/integration_utils.rs
@@ -93,8 +93,11 @@ pub fn get_encryption_msg(user_pubkey: [u8; 64]) -> Value {
     json!({"id" : &generate_job_id(), "type" : "NewTaskEncryptionKey", "userPubKey": user_pubkey.to_hex()})
 }
 
-pub fn get_ptt_req_msg() -> Value {
-    json!({"id" : &generate_job_id(), "type" : "GetPTTRequest"})
+pub fn get_ptt_req_msg(addresses: Option<Vec<String>>) -> Value {
+    match addresses {
+        None => json!({"id" : &generate_job_id(), "type" : "GetPTTRequest"}),
+        Some(addrs) =>  json!({"id" : &generate_job_id(), "type" : "GetPTTRequest", "input": { "addresses": addrs} }),
+    }
 }
 
 pub fn get_ptt_res_msg(response: &[u8]) -> Value {
@@ -154,7 +157,7 @@ pub fn mock_principal_res(msg: &str, addrs: Vec<ContractAddress>) -> Vec<u8> {
 pub fn run_ptt_round(port: &'static str, addrs: Vec<ContractAddress>) -> Value {
 
     // set encrypted request message to send to the principal node
-    let msg_req = get_ptt_req_msg();
+    let msg_req = get_ptt_req_msg(None);
     let req_val: Value = conn_and_call_ipc(&msg_req.to_string(), port);
     let packed_msg = req_val["result"]["request"].as_str().unwrap();
 

--- a/enigma-core/app/tests/ipc_identity_and_general_tests.rs
+++ b/enigma-core/app/tests/ipc_identity_and_general_tests.rs
@@ -66,6 +66,27 @@ fn test_run_ptt_twice() {
     //todo what should we expect to happen?
 }
 
+
+#[test]
+fn test_run_ptt_with_addresses() {
+    use integration_utils::*;
+    let port = "3978";
+    run_core(port);
+    let addresses = vec![generate_contract_address(), generate_contract_address()];
+    let address_string: Vec<_> = addresses.iter().map(|a| a.to_hex()).collect();
+    let msg_req = get_ptt_req_msg(Some(address_string));
+    let req_val: Value = conn_and_call_ipc(&msg_req.to_string(), port);
+    let packed_msg = req_val["result"]["request"].as_str().unwrap();
+    let enc_response = mock_principal_res(packed_msg, addresses);
+    let msg = get_ptt_res_msg(&enc_response);
+    let res = conn_and_call_ipc(&msg.to_string(), port);
+
+    assert!(res["result"]["errors"].as_array().unwrap().is_empty());
+    assert!(res["id"].is_string());
+    assert_eq!(res["type"].as_str().unwrap(), "PTTResponse");
+}
+
+
 #[test]
 fn test_deploy_same_contract_twice() {
     let port = "5578";

--- a/enigma-core/app/tests/ipc_key_exchange_tests.rs
+++ b/enigma-core/app/tests/ipc_key_exchange_tests.rs
@@ -14,7 +14,7 @@ fn test_get_ptt_request() {
     let port = "5558";
     run_core(port);
 
-    let msg = get_ptt_req_msg();
+    let msg = get_ptt_req_msg(None);
     let v: Value = conn_and_call_ipc(&msg.to_string(), port);
 
     let packed_msg = v["result"]["request"].as_str().unwrap();


### PR DESCRIPTION
Before it wanted to accept a message like:
`{"id" : &generate_job_id(), "type" : "GetPTTRequest", "input": addresses}`

now it will accept: 
`{"id" : &generate_job_id(), "type" : "GetPTTRequest", "input": { "addresses": addresses} })`

as specified here: https://github.com/enigmampc/enigma-p2p/blob/develop/docs/IPC_MESSAGES.md#getpttrequest-message