### PR TITLE
Fix failing builds

### DIFF
--- a/enigma-core/app/Cargo.lock
+++ b/enigma-core/app/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,6 +555,7 @@ name = "enigma-tools-u"
 version = "0.1.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
@@ -581,6 +583,7 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/enigma-core/enclave/Cargo.lock
+++ b/enigma-core/enclave/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -252,6 +253,7 @@ dependencies = [
 name = "enigma-tools-m"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
  "etcommon-bigint 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -272,6 +274,7 @@ dependencies = [
 name = "enigma-tools-t"
 version = "0.1.3"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-tools-m 0.1.0",
  "enigma-types 0.1.0",
@@ -299,6 +302,7 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.4)",

--- a/enigma-crypto/Cargo.toml
+++ b/enigma-crypto/Cargo.toml
@@ -23,6 +23,9 @@ sgx_tstd = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", 
 sgx_trts = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", optional = true }
 sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", optional = true }
 
+bitflags = "=1.0.4"
+
+
 # Right now symmetric encryption requires regular std or sgx std.
 [features]
 default = ["std", "symmetric", "asymmetric", "hash"]

--- a/enigma-principal/app/Cargo.lock
+++ b/enigma-principal/app/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -424,6 +425,7 @@ dependencies = [
 name = "enigma-tools-m"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
  "etcommon-bigint 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -444,6 +446,7 @@ name = "enigma-tools-u"
 version = "0.1.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
@@ -471,6 +474,7 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/enigma-principal/enclave/Cargo.lock
+++ b/enigma-principal/enclave/Cargo.lock
@@ -191,6 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -207,6 +208,7 @@ dependencies = [
 name = "enigma-tools-m"
 version = "0.1.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
  "etcommon-bigint 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -227,6 +229,7 @@ dependencies = [
 name = "enigma-tools-t"
 version = "0.1.3"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-tools-m 0.1.0",
  "enigma-types 0.1.0",
@@ -254,6 +257,7 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.71 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.4)",

--- a/enigma-tools-m/Cargo.toml
+++ b/enigma-tools-m/Cargo.toml
@@ -28,6 +28,8 @@ sgx_tstd = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", 
 serde_sgx = { package = "serde", git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", default-features = false, optional = true }
 serde_json_sgx = { package = "serde_json", git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", optional = true }
 
+bitflags = "=1.0.4"
+
 [features]
 default = ["std"]
 std = ["ethabi_std", "enigma-types/std", "ethereum_types_std", "enigma-crypto/std", "rmp_serde_std", "serde_std", "serde_json_std"]

--- a/enigma-tools-t/Cargo.toml
+++ b/enigma-tools-t/Cargo.toml
@@ -22,7 +22,10 @@ serde = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", def
 serde_json = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4" }
 json-patch = { git = "https://github.com/enigmampc/json-patch.git", rev = "sgx-0.2.2-v1.0.4", default-features = false }
 wasmi = { git = "https://github.com/enigmampc/wasmi", default-features = false, features = ["core"] }
+
 hashmap_core = "=0.1.9"
+bitflags = "=1.0.4"
+
 
 sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4" }
 sgx_tstd = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4" }

--- a/enigma-tools-u/Cargo.toml
+++ b/enigma-tools-u/Cargo.toml
@@ -23,6 +23,7 @@ log-derive = "0.2.0"
 simplelog = "0.5.3"
 dirs = "1.0.4"
 rustc-demangle = "=0.1.13"
+bitflags = "=1.0.4"
 
 # TODO: Change after a new version is released.
 # Add more transport layers via features if needed.

--- a/enigma-types/Cargo.toml
+++ b/enigma-types/Cargo.toml
@@ -13,6 +13,8 @@ arrayvec = { version = "0.4.10", default-features = false }
 serde_sgx = { package = "serde", git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.4", optional = true }
 serde_std = { package = "serde", version = "1.0", default-features = false }
 
+bitflags = "=1.0.4"
+
 [build-dependencies]
 cbindgen = "0.8"
 

--- a/examples/eng_wasm_contracts/erc20/Cargo.toml
+++ b/examples/eng_wasm_contracts/erc20/Cargo.toml
@@ -9,6 +9,8 @@ enigma-crypto = { path = "../../../enigma-crypto", default-features = false, fea
 rustc-hex = "2.0.1"
 serde = { version = "1.0", default-features = false, features=["serde_derive"] }
 
+bitflags = "=1.0.4"
+
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
`bitflags` released a new version (1.0.5) which uses an unstable feature on our current nightly version.
this locks bitflags dependency to version 1.0.4

we should be able to remove this lock after our next compiler upgrade (hopefully next week to baidu's 1.0.7 release)