### PR TITLE
Removed version locks and resolved warnings

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,12 +22,11 @@ steps:
     image: enigmampc/enigma-core:0.0.7
     depends_on: [clone]
     privileged: true
-    enviroment:
-      - NODE_URL: http://ganache:8545
     commands:
       - LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service
       - . /opt/sgxsdk/environment && . /root/.cargo/env
       - cd enigma-principal && RUSTFLAGS=-Awarnings make DEBUG=1
+      - export NODE_URL="http://ganache:8545"
       - cd app && RUSTFLAGS=-Awarnings cargo test
     volumes:
       - name: isgx
@@ -36,8 +35,6 @@ steps:
   - name: tools_u
     image: enigmampc/enigma-core:0.0.7
     depends_on: [clone]
-    enviroment:
-      - NODE_URL: http://ganache:8545
     commands:
       - . /root/.cargo/env
       - export NODE_URL="http://ganache:8545"

--- a/eng-wasm/derive/src/lib.rs
+++ b/eng-wasm/derive/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(unused_extern_crates)]
 #![feature(box_patterns)]
 #![recursion_limit="128"]
-#![feature(int_to_from_bytes)]
 #![feature(slice_concat_ext)]
 
 extern crate eng_wasm;
@@ -11,7 +10,6 @@ extern crate proc_macro;
 #[macro_use]
 extern crate syn;
 extern crate ethabi;
-#[macro_use]
 extern crate failure;
 extern crate tiny_keccak;
 
@@ -249,7 +247,7 @@ fn read_contract_file(file_path: String) -> Result<Box<File>, EngWasmError>{
     Ok(contents)
 }
 
-fn generate_eth_functions(contract: &Contract) -> Result<Box<Vec<proc_macro2::TokenStream>>,EngWasmError>{
+fn generate_eth_functions(contract: &Contract) -> Result<Vec<proc_macro2::TokenStream>,EngWasmError>{
     let mut functions: Vec<FunctionAst> = Vec::new();
     for function in &contract.functions{
         let mut args_ast_types = Vec::new();
@@ -297,7 +295,7 @@ fn generate_eth_functions(contract: &Contract) -> Result<Box<Vec<proc_macro2::To
         }
     }).collect();
 
-    Ok(Box::new(result))
+    Ok(result)
 }
 
 #[proc_macro_attribute]
@@ -308,7 +306,7 @@ pub fn eth_contract(args: proc_macro::TokenStream, input: proc_macro::TokenStrea
     let file_path = parse_macro_input!(args as syn::LitStr);
     let mut contents: Box<File> = read_contract_file(file_path.value()).expect("Bad contract file");
     let contract = Contract::load(contents).unwrap();
-    let it: Vec<proc_macro2::TokenStream> = *generate_eth_functions(&contract).unwrap();
+    let it: Vec<proc_macro2::TokenStream> = generate_eth_functions(&contract).unwrap();
 
     let result = quote! {
         struct #struct_name {

--- a/eng-wasm/src/lib.rs
+++ b/eng-wasm/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(slice_concat_ext)]
-#![feature(int_to_from_bytes)]
 #![deny(unused_extern_crates)]
 
 /// Enigma implementation of bindings to the Enigma runtime.

--- a/enigma-core/app/Cargo.lock
+++ b/enigma-core/app/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -445,6 +445,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,12 +541,12 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust.git)",
- "rocksdb 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -531,7 +563,6 @@ dependencies = [
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -554,7 +585,7 @@ dependencies = [
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust.git)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +597,6 @@ name = "enigma-tools-u"
 version = "0.1.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
@@ -575,18 +605,16 @@ dependencies = [
  "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_types 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "sgx_urts 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -595,7 +623,6 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -945,6 +972,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,9 +1119,10 @@ dependencies = [
 
 [[package]]
 name = "log-derive"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1134,7 +1167,7 @@ name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1214,9 +1247,9 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1280,7 +1313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl"
-version = "0.10.21"
+version = "0.10.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1288,7 +1321,7 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1298,13 +1331,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.44"
+version = "0.9.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1684,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1693,7 +1726,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1894,6 +1927,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "string"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2296,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2544,6 +2582,9 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
@@ -2588,6 +2629,7 @@ dependencies = [
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e4606fed1c162e3a63d408c07584429f49a4f34c7176cb6cbee60e78f2372c"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -2606,7 +2648,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2e751afd5f14c15342a85485416446a723b879f7233258a59a5d4363e941b1"
+"checksum log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90b7e153f2d4bf69d46a9e640e2c96573940fca671d275bf6f7687f6bab803fc"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
@@ -2628,9 +2670,9 @@ dependencies = [
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-"checksum openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)" = "615b325b964d8fb0533e7fad5867f63677bbc79a274c9cd7a19443e1a6fcdd9e"
+"checksum openssl 0.10.22 (registry+https://github.com/rust-lang/crates.io-index)" = "a51f452b82d622fc8dd973d7266e9055ac64af25b957d9ced3989142dc61cb6b"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-"checksum openssl-sys 0.9.44 (registry+https://github.com/rust-lang/crates.io-index)" = "50bacc164f352df4c943e77e6f13a09f3dfe1407b6b144f9deba30e4b63e1db3"
+"checksum openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)" = "05636e06b4f8762d4b81d24a351f3966f38bd25ccbcfd235606c91fdb82cc60f"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
@@ -2670,8 +2712,8 @@ dependencies = [
 "checksum ring 0.14.6 (git+https://github.com/elichai/ring.git?rev=sgx-0.14.6)" = "<none>"
 "checksum rmp 0.8.7 (git+https://github.com/3Hren/msgpack-rust.git)" = "<none>"
 "checksum rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust.git)" = "<none>"
-"checksum rocksdb 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3eca7dfb97566985090e6bc4a529af42d0adda683d346a024104ee1b1932e340"
-"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum rocksdb 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d29e12aab379a49bfbca337132440be73d1de6f328d5635641c2b28ac9dfe514"
+"checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
@@ -2700,6 +2742,7 @@ dependencies = [
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
@@ -2738,7 +2781,7 @@ dependencies = [
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "754ba11732b9161b94c41798e5197e5e75388d012f760c42adb5000353e98646"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-"checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
+"checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"

--- a/enigma-core/app/Cargo.toml
+++ b/enigma-core/app/Cargo.toml
@@ -19,11 +19,11 @@ failure = "0.1.3"
 rustc-hex = "1.0.0" # 2.0.1?
 dirs = "1.0.4"
 # TODO: Add compression as a feature and use it in `set_compression_type()`
-rocksdb = { version = "=0.12.1", default-features = false } # TODO: Update the rocksdb lib https://github.com/rust-rocksdb/rust-rocksdb/issues/304
-lazy_static = "1.2.0"
+rocksdb = { version = "0.12.2", default-features = false } # TODO: Update the rocksdb lib https://github.com/rust-rocksdb/rust-rocksdb/issues/304
+lazy_static = "1.3.0"
 lru-cache = "0.1.1"
 log = "0.4.6"
-log-derive = "0.2"
+log-derive = "0.3"
 simplelog = "0.5.3"
 structopt = "0.2"
 

--- a/enigma-core/app/cross-test-utils/src/lib.rs
+++ b/enigma-core/app/cross-test-utils/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(int_to_from_bytes)]
+
 extern crate enigma_types;
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;

--- a/enigma-core/app/src/db/dal.rs
+++ b/enigma-core/app/src/db/dal.rs
@@ -377,7 +377,7 @@ mod test {
     #[test]
     #[should_panic]
     fn test_fail_cf_exists_no_key_read() {
-        let (mut db, _dir) = create_test_db();
+        let (db, _dir) = create_test_db();
 
         let arr = [3u8; 32];
         let _cf = db.database.create_cf(&arr.to_hex(), &db.options).unwrap();

--- a/enigma-core/app/src/db/dal.rs
+++ b/enigma-core/app/src/db/dal.rs
@@ -50,7 +50,7 @@ impl DB {
             Err(_) => Vec::new(),
         };
         // converts the Strings to slices (str)
-        let cf_list_burrowed = cf_list.iter().map(|i| i.as_str()).collect::<Vec<&str>>();
+        let cf_list_burrowed = cf_list.iter().map(String::as_str).collect::<Vec<&str>>();
         let database = rocks_db::open_cf(&options, &location, &cf_list_burrowed[..])?;
         let location = location.as_ref().to_path_buf();
         let db_par = DB { location, database, options };

--- a/enigma-core/app/src/esgx/ocalls_u.rs
+++ b/enigma-core/app/src/esgx/ocalls_u.rs
@@ -8,6 +8,7 @@ use std::{ptr, slice};
 
 lazy_static! { static ref DELTAS_CACHE: Mutex<LruCache<Hash256, Vec<Vec<u8>>>> = Mutex::new(LruCache::new(500)); }
 
+
 #[no_mangle]
 pub unsafe extern "C" fn ocall_update_state(db_ptr: *const RawPointer, id: &ContractAddress, enc_state: *const u8, state_len: usize) -> EnclaveReturn {
     let encrypted_state = slice::from_raw_parts(enc_state, state_len);
@@ -28,6 +29,7 @@ pub unsafe extern "C" fn ocall_update_state(db_ptr: *const RawPointer, id: &Cont
         }
     }
 }
+
 
 #[no_mangle]
 pub unsafe extern "C" fn ocall_new_delta(db_ptr: *const RawPointer,
@@ -52,6 +54,7 @@ pub unsafe extern "C" fn ocall_new_delta(db_ptr: *const RawPointer,
     }
 }
 
+
 #[no_mangle]
 pub unsafe extern "C" fn ocall_get_state_size(db_ptr: *const RawPointer, addr: &ContractAddress, state_size: *mut usize) -> EnclaveReturn {
     let mut cache_id = addr.to_vec();
@@ -74,6 +77,7 @@ pub unsafe extern "C" fn ocall_get_state_size(db_ptr: *const RawPointer, addr: &
         Err(_) => EnclaveReturn::OcallDBError,
     }
 }
+
 
 #[no_mangle]
 pub unsafe extern "C" fn ocall_get_state(db_ptr: *const RawPointer, addr: &ContractAddress, state_ptr: *mut u8, state_size: usize) -> EnclaveReturn {
@@ -106,6 +110,7 @@ pub unsafe extern "C" fn ocall_get_state(db_ptr: *const RawPointer, addr: &Contr
         }
     }
 }
+
 
 #[no_mangle]
 pub unsafe extern "C" fn ocall_get_deltas_sizes(db_ptr: *const RawPointer, addr: &ContractAddress,
@@ -146,6 +151,7 @@ pub unsafe extern "C" fn ocall_get_deltas_sizes(db_ptr: *const RawPointer, addr:
     enigma_types::write_ptr(&sizes, res_ptr, res_len);
     EnclaveReturn::Success
 }
+
 
 #[no_mangle]
 pub unsafe extern "C" fn ocall_get_deltas(db_ptr: *const RawPointer, addr: &ContractAddress,

--- a/enigma-core/app/src/esgx/ocalls_u.rs
+++ b/enigma-core/app/src/esgx/ocalls_u.rs
@@ -1,3 +1,4 @@
+#![allow(unused_attributes)]
 use crate::db::{CRUDInterface, DeltaKey, P2PCalls, ResultType, ResultTypeVec, Stype, DB};
 use enigma_crypto::hash::Sha256;
 use enigma_tools_m::utils::LockExpectMutex;

--- a/enigma-core/app/src/km_u.rs
+++ b/enigma-core/app/src/km_u.rs
@@ -243,10 +243,10 @@ pub mod tests {
         ];
 
         let mut keys = Vec::with_capacity(addresses.len());
-        for ((mut state, deltas, key), address) in encrypted_data().into_iter().zip(addresses.iter()) {
+        for ((state, deltas, key), address) in encrypted_data().into_iter().zip(addresses.iter()) {
             let state = symmetric::encrypt(&state, &key).unwrap();
             stuff.push((DeltaKey { contract_address: *address, key_type: State}, state));
-            for (j, mut delta) in deltas.into_iter().enumerate() {
+            for (j, delta) in deltas.into_iter().enumerate() {
                 stuff.push((DeltaKey { contract_address: *address, key_type: Delta(j as u32)}, delta));
             }
             keys.push(key);

--- a/enigma-core/app/src/lib.rs
+++ b/enigma-core/app/src/lib.rs
@@ -1,7 +1,4 @@
-#![feature(tool_lints)]
 #![warn(clippy::all)]
-#![feature(try_from)]
-#![feature(int_to_from_bytes)]
 #![warn(unused_extern_crates)]
 
 extern crate dirs;

--- a/enigma-core/app/src/lib.rs
+++ b/enigma-core/app/src/lib.rs
@@ -66,6 +66,7 @@ mod tests {
         (db, tempdir)
     }
 
+    #[allow(dead_code)]
     pub fn log_to_stdout(level: Option<LevelFilter>) {
         let level = level.unwrap_or_else(|| LevelFilter::max());
         TermLogger::init(level, Default::default()).unwrap();

--- a/enigma-core/app/src/wasm_u/wasm.rs
+++ b/enigma-core/app/src/wasm_u/wasm.rs
@@ -86,7 +86,7 @@ mod tests {
     use crate::km_u::tests::instantiate_encryption_key;
     use crate::db::{DB, tests::create_test_db};
     use crate::wasm_u::wasm;
-    use self::ethabi::{Contract, Function, Token, token::{LenientTokenizer, Tokenizer}};
+    use self::ethabi::{Contract, Token, token::{LenientTokenizer, Tokenizer}};
     use enigma_types::{ContractAddress, DhKey, PubKey};
     use enigma_crypto::symmetric;
     use hex::FromHex;
@@ -217,7 +217,7 @@ mod tests {
         let (mut db, _dir) = create_test_db();
         let address = generate_contract_address();
 
-        let (enclave, contract_code, result, shared_key) = compile_deploy_execute(
+        let (enclave, contract_code, result, _) = compile_deploy_execute(
             &mut db,
             "../../examples/eng_wasm_contracts/simplest",
             address,
@@ -285,7 +285,7 @@ mod tests {
         let (keys, shared_key, _, _) = exchange_keys(enclave.geteid());
         let mut encrypted_callable = symmetric::encrypt(b"commit(bool)", &shared_key).unwrap();
         let mut encrypted_args = symmetric::encrypt(&ethabi::encode(&[Token::Bool(commitment)]), &shared_key).unwrap();
-        let mut result = wasm::execute(
+        let _ = wasm::execute(
             &mut db,
             enclave.geteid(),
             &contract_code,
@@ -299,7 +299,7 @@ mod tests {
         let (keys, shared_key, _, _) = exchange_keys(enclave.geteid());
         encrypted_callable = symmetric::encrypt(b"guess(bool)", &shared_key).unwrap();
         encrypted_args = symmetric::encrypt(&ethabi::encode(&[Token::Bool(commitment.into())]), &shared_key).unwrap();
-        result = wasm::execute(
+        let result = wasm::execute(
             &mut db,
             enclave.geteid(),
             &contract_code,
@@ -769,7 +769,7 @@ mod tests {
         let (mut db, _dir) = create_test_db();
         let a = Token::Uint(10.into());
         let b = Token::Uint(20.into());
-        let (_, _, result, shared_key) = compile_deploy_execute(
+        let _ = compile_deploy_execute(
             &mut db,
             "../../examples/eng_wasm_contracts/simple_calculator",
             generate_contract_address(),
@@ -808,7 +808,7 @@ mod tests {
         let (mut db, _dir) = create_test_db();
         let a = Token::Uint(Uint::MAX);
         let b = Token::Uint(76.into());
-        let (_, _, result, shared_key) = compile_deploy_execute(
+        let _ = compile_deploy_execute(
             &mut db,
             "../../examples/eng_wasm_contracts/simple_calculator",
             generate_contract_address(),
@@ -847,7 +847,7 @@ mod tests {
         let (mut db, _dir) = create_test_db();
         let a = Token::Uint(76.into());
         let b = Token::Uint(0.into());
-        let (_, _, result, shared_key) = compile_deploy_execute(
+        let _ = compile_deploy_execute(
             &mut db,
             "../../examples/eng_wasm_contracts/simple_calculator",
             generate_contract_address(),

--- a/enigma-core/app/tests/ipc_read_db_tests.rs
+++ b/enigma-core/app/tests/ipc_read_db_tests.rs
@@ -2,7 +2,7 @@ pub mod integration_utils;
 
 use integration_utils::{run_core, full_simple_deployment, deploy_and_compute_few_contracts,
                         conn_and_call_ipc, get_msg_format_with_input, get_get_tips_msg, get_delta_msg,
-                        get_deltas_msg, get_simple_msg_format, decrypt_delta_to_value, is_hex};
+                        get_deltas_msg, get_simple_msg_format, decrypt_delta_to_value};
 pub extern crate enigma_core_app as app;
 extern crate serde;
 extern crate rustc_hex as hex;

--- a/enigma-core/enclave/Cargo.lock
+++ b/enigma-core/enclave/Cargo.lock
@@ -161,6 +161,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,7 +226,7 @@ dependencies = [
  "etcommon-bigint 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "etcommon-hexutil 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 6.1.0 (git+https://github.com/enigmampc/ethabi.git?rev=sgx-v6.1.0-v1.0.7)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (git+https://github.com/enigmampc/parity-wasm.git?branch=enigma)",
  "pwasm-utils 0.5.0 (git+https://github.com/enigmampc/wasm-utils.git?rev=sgx-1.0.7)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -212,7 +244,6 @@ dependencies = [
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -254,7 +285,7 @@ dependencies = [
  "ethereum-types 0.4.0 (git+https://github.com/enigmampc/primitives.git?rev=sgx-v0.4.0)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/enigmampc/msgpack-rust.git?rev=sgx-v1.0.7)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
@@ -293,7 +324,6 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
@@ -408,6 +438,11 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +485,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itoa"
 version = "0.4.1"
 source = "git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7#6365e740c34e3357726eb3c2e8c85a551919f1b0"
@@ -476,10 +516,10 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -510,9 +550,10 @@ dependencies = [
 
 [[package]]
 name = "log-derive"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -724,7 +765,7 @@ version = "0.14.6"
 source = "git+https://github.com/elichai/ring.git?rev=sgx-0.14.6#1454e91f6395f6f42033402da38b394bb4941a05"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -976,11 +1017,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1006,6 +1042,11 @@ dependencies = [
  "etcommon-bigint 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "sputnikvm 0.10.1 (git+https://github.com/enigmampc/sputnikvm.git?rev=enigma-next)",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -1186,6 +1227,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum elastic-array-plus 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "562cc8504a01eb20c10fb154abd7c4baeb9beba2329cf85838ee2bd48a468b18"
@@ -1201,19 +1245,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixed-hash 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7afe6ce860afb14422711595a7b26ada9ed7de2f43c0b2ab79d09ee196287273"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
 "checksum hmac-drbg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe727d41d2eec0a6574d887914347e5ff96a3b87177817e2a9820c5c87fecc2"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum itoa 0.4.1 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)" = "<none>"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum json-patch 0.2.5 (git+https://github.com/enigmampc/json-patch.git?rev=sgx-0.2.5-v1.0.7)" = "<none>"
-"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)" = "c6785aa7dd976f5fbf3b71cfd9cd49d7f783c1ff565a858d71031c6c313aa5c6"
 "checksum libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "688e8d65e495567c2c35ea0001b26b9debf0b4ea11f8cccc954233b75fc3428a"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2e751afd5f14c15342a85485416446a723b879f7233258a59a5d4363e941b1"
+"checksum log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90b7e153f2d4bf69d46a9e640e2c96573940fca671d275bf6f7687f6bab803fc"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-traits 0.2.5 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)" = "<none>"
@@ -1266,10 +1312,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum sha3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26405905b6a56a94c60109cfda62610507ac14a65be531f5767dec5c5a8dd6a0"
-"checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum sputnikvm 0.10.1 (git+https://github.com/enigmampc/sputnikvm.git?rev=enigma-next)" = "<none>"
 "checksum sputnikvm-network-classic 0.10.0 (git+https://github.com/enigmampc/sputnikvm.git?rev=enigma-next)" = "<none>"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"

--- a/enigma-core/enclave/Cargo.toml
+++ b/enigma-core/enclave/Cargo.toml
@@ -20,7 +20,7 @@ enigma-tools-t = { path = "../../enigma-tools-t" }
 enigma-tools-m = { path = "../../enigma-tools-m", default-features = false, features = ["sgx"] }
 enigma-runtime-t = { path = "../../enigma-runtime-t" }
 
-lazy_static = {version = "=1.2.0", features = ["spin_no_std"] }
+lazy_static = {version = "1.3.0", features = ["spin_no_std"] }
 etcommon-hexutil = { version = "0.2", default-features = false }
 etcommon-bigint = { version = "0.2", default-features = false, features = ["rlp"] }
 rustc-hex = { version = "2.0", default-features = false }

--- a/enigma-core/enclave/src/km_t/mod.rs
+++ b/enigma-core/enclave/src/km_t/mod.rs
@@ -23,14 +23,6 @@ pub fn get_state_key(address: ContractAddress) -> Result<StateKey, EnclaveError>
         .ok_or(CryptoError::MissingKeyError { key_type: "State Key" })?)
 }
 
-pub fn encrypt_delta(del: StatePatch) -> Result<EncryptedPatch, EnclaveError> {
-    let statekeys_guard = STATE_KEYS.lock_expect("State Keys");
-    let key = statekeys_guard
-        .get(&del.contract_address)
-        .ok_or(CryptoError::MissingKeyError { key_type: "State Key" })?;
-    del.encrypt(&key)
-}
-
 pub fn encrypt_state(state: ContractState) -> Result<EncryptedContractState<u8>, EnclaveError> {
     let statekeys_guard = STATE_KEYS.lock_expect("State Keys");
     let key = statekeys_guard

--- a/enigma-core/enclave/src/km_t/principal.rs
+++ b/enigma-core/enclave/src/km_t/principal.rs
@@ -74,7 +74,7 @@ pub(crate) fn ecall_build_state_internal(db_ptr: *const RawPointer) -> Result<Ve
         };
 
         'deltas: while start < u32::MAX {
-            let mut end = start + 500;
+            let end = start + 500;
             // Get deltas from start to end, if fails save the latest state and move on.
             let deltas = match runtime_ocalls_t::get_deltas(db_ptr, *addrs, start, end) {
                 Ok(deltas) => deltas,

--- a/enigma-core/enclave/src/lib.rs
+++ b/enigma-core/enclave/src/lib.rs
@@ -1,11 +1,7 @@
 #![crate_name = "enigmacoreenclave"]
 #![crate_type = "staticlib"]
 #![no_std]
-//#![cfg_attr(not(target_env = "sgx"), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
-#![feature(tool_lints)]
-#![feature(int_to_from_bytes)]
 #![warn(clippy::all)]
 #![allow(clippy::cast_ptr_alignment)] // TODO: Try to remove it when fixing the sealing
 #![warn(unused_extern_crates)]

--- a/enigma-core/enclave/src/wasm_g/execution.rs
+++ b/enigma-core/enclave/src/wasm_g/execution.rs
@@ -122,7 +122,7 @@ pub fn execute_call(code: &[u8], gas_limit: u64, state: ContractState,
     let module = create_module(code)?;
     let mut runtime = execute(&module, gas_limit, state, function_name, types, params, key)?;
     let charge_result = runtime.charge_execution();
-    if let Err(err) = charge_result {
+    if let Err(_) = charge_result {
         return Err(EnclaveError::FailedTaskErrorWithGas { used_gas: runtime.get_used_gas(), err: FailedTaskError::GasLimitError });
     }
     runtime.into_result()
@@ -133,7 +133,7 @@ pub fn execute_constructor(code: &[u8], gas_limit: u64, state: ContractState, pa
     let module = create_module(code)?;
     let mut runtime = execute(&module, gas_limit, state, "".to_string(), "".to_string(), params, key)?;
     let charge_result = runtime.charge_deployment();
-    if let Err(err) = charge_result {
+    if let Err(_) = charge_result {
         return Err(EnclaveError::FailedTaskErrorWithGas { used_gas: runtime.get_used_gas(), err: FailedTaskError::GasLimitError  });
     }
     runtime.into_result()

--- a/enigma-crypto/Cargo.toml
+++ b/enigma-crypto/Cargo.toml
@@ -21,8 +21,6 @@ sgx_tstd = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7", 
 sgx_trts = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7", optional = true }
 sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7", optional = true }
 
-bitflags = "=1.0.4"
-
 
 # Right now symmetric encryption requires regular std or sgx std.
 [features]

--- a/enigma-crypto/src/hash.rs
+++ b/enigma-crypto/src/hash.rs
@@ -46,7 +46,7 @@ impl Keccak256<Hash256> for [u8] {
 
 impl Sha256<Hash256> for [u8] {
     fn sha256(&self) -> Hash256 {
-        use sha2::{self, Digest};
+        use sha2::Digest;
         let mut hasher = sha2::Sha256::new();
         hasher.input(&self);
         let mut result = Hash256::default();

--- a/enigma-crypto/src/lib.rs
+++ b/enigma-crypto/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(int_to_from_bytes)]
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![deny(unused_extern_crates)]
 

--- a/enigma-principal/app/Cargo.lock
+++ b/enigma-principal/app/Cargo.lock
@@ -227,11 +227,11 @@ dependencies = [
 
 [[package]]
 name = "colour"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -351,6 +351,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,7 +430,6 @@ dependencies = [
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +444,7 @@ dependencies = [
 name = "enigma-principal-app"
 version = "0.1.3"
 dependencies = [
- "colour 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colour 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-tools-m 0.1.0",
@@ -426,7 +457,7 @@ dependencies = [
  "jsonrpc-http-server 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-test 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,7 +466,6 @@ dependencies = [
  "sgx_types 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "sgx_urts 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -452,7 +482,7 @@ dependencies = [
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/3Hren/msgpack-rust.git)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -464,7 +494,6 @@ name = "enigma-tools-u"
 version = "0.1.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-crypto 0.1.0",
  "enigma-types 0.1.0",
@@ -473,18 +502,16 @@ dependencies = [
  "ethabi 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_types 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "sgx_urts 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -493,7 +520,6 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,6 +842,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,9 +1034,10 @@ dependencies = [
 
 [[package]]
 name = "log-derive"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1774,6 +1806,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1829,15 +1866,6 @@ dependencies = [
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2333,7 +2361,7 @@ dependencies = [
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum colour 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab9acd08871a0129946ffa7cde82f4b3f92c0af303f855d211913d95bcb6b1ae"
+"checksum colour 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a328d8ddb37e76b43ee7da69a58f59c0c72d5cf8c091d004712f3154b41cd7"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "99be24cfcf40d56ed37fd11c2123be833959bbc5bddecb46e1c2e442e15fa3e0"
 "checksum cookie_store 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b0d2f2ecb21dce00e2453268370312978af9b8024020c7a37ae2cc6dbbe64685"
@@ -2347,6 +2375,9 @@ dependencies = [
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
@@ -2386,6 +2417,7 @@ dependencies = [
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e4606fed1c162e3a63d408c07584429f49a4f34c7176cb6cbee60e78f2372c"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -2406,7 +2438,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2e751afd5f14c15342a85485416446a723b879f7233258a59a5d4363e941b1"
+"checksum log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90b7e153f2d4bf69d46a9e640e2c96573940fca671d275bf6f7687f6bab803fc"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -2495,13 +2527,13 @@ dependencies = [
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
-"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"

--- a/enigma-principal/app/Cargo.toml
+++ b/enigma-principal/app/Cargo.toml
@@ -20,13 +20,12 @@ serde_derive = "1.0"
 rmp-serde = "0.13.7"
 structopt = "0.2.10"
 url = "1.7.1"
-colour = "0.2.1"
+colour = "0.3"
 dirs = "1.0"
 web3 = { version  = "0.6", default-features = false, features=["http"]  }
 jsonrpc-http-server = "11.0.0"
 log = "0.4.6"
-log-derive = "0.2"
-unicase = "=2.2.0"
+log-derive = "0.3"
 
 sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7" }
 sgx_urts = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7" }

--- a/enigma-principal/app/src/main.rs
+++ b/enigma-principal/app/src/main.rs
@@ -1,5 +1,4 @@
 #![feature(integer_atomics)]
-#![feature(try_from)]
 #![feature(arbitrary_self_types)]
 
 #[macro_use]

--- a/enigma-principal/enclave/Cargo.lock
+++ b/enigma-principal/enclave/Cargo.lock
@@ -161,6 +161,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "enigma-crypto"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "enigma-types 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -210,7 +241,7 @@ dependencies = [
  "ethereum-types 0.4.0 (git+https://github.com/enigmampc/primitives.git?rev=sgx-v0.4.0)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp-serde 0.14.0 (git+https://github.com/enigmampc/msgpack-rust.git?rev=sgx-v1.0.7)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
@@ -249,7 +280,6 @@ name = "enigma-types"
 version = "0.1.0"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
@@ -266,7 +296,7 @@ dependencies = [
  "enigma-types 0.1.0",
  "ethabi 6.1.0 (git+https://github.com/enigmampc/ethabi.git?rev=sgx-v6.1.0-v1.0.7)",
  "ethereum-types 0.4.0 (git+https://github.com/enigmampc/primitives.git?rev=sgx-v0.4.0)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_trts 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
  "sgx_tstd 1.0.7 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)",
@@ -371,6 +401,11 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fnv"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +448,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "itoa"
 version = "0.4.1"
 source = "git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7#6365e740c34e3357726eb3c2e8c85a551919f1b0"
@@ -438,10 +478,10 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -472,9 +512,10 @@ dependencies = [
 
 [[package]]
 name = "log-derive"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -686,7 +727,7 @@ version = "0.14.6"
 source = "git+https://github.com/elichai/ring.git?rev=sgx-0.14.6#1454e91f6395f6f42033402da38b394bb4941a05"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -916,12 +957,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.4.10"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "spin"
-version = "0.5.0"
+name = "strsim"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1094,6 +1135,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
+"checksum darling 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fcfbcb0c5961907597a7d1148e3af036268f2b773886b8bb3eeb1e1281d3d3d6"
+"checksum darling_core 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6afc018370c3bff3eb51f89256a6bdb18b4fdcda72d577982a14954a7a0b402c"
+"checksum darling_macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6d8dac1c6f1d29a41c4712b4400f878cb4fcc4c7628f298dd75038e024998d1"
 "checksum digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5b29bf156f3f4b3c4f610a25ff69370616ae6e0657d416de22645483e72af0a"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum elastic-array-plus 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "562cc8504a01eb20c10fb154abd7c4baeb9beba2329cf85838ee2bd48a468b18"
@@ -1108,19 +1152,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixed-hash 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7afe6ce860afb14422711595a7b26ada9ed7de2f43c0b2ab79d09ee196287273"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fceb69994e330afed50c93524be68c42fa898c2d9fd4ee8da03bd7363acd26f2"
 "checksum hmac 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a13f4163aa0c5ca1be584aace0e2212b2e41be5478218d4f657f5f778b2ae2a"
 "checksum hmac-drbg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe727d41d2eec0a6574d887914347e5ff96a3b87177817e2a9820c5c87fecc2"
+"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum itoa 0.4.1 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)" = "<none>"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum json-patch 0.2.5 (git+https://github.com/enigmampc/json-patch.git?rev=sgx-0.2.5-v1.0.7)" = "<none>"
-"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)" = "c6785aa7dd976f5fbf3b71cfd9cd49d7f783c1ff565a858d71031c6c313aa5c6"
 "checksum libsecp256k1 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "688e8d65e495567c2c35ea0001b26b9debf0b4ea11f8cccc954233b75fc3428a"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
-"checksum log-derive 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2e751afd5f14c15342a85485416446a723b879f7233258a59a5d4363e941b1"
+"checksum log-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90b7e153f2d4bf69d46a9e640e2c96573940fca671d275bf6f7687f6bab803fc"
 "checksum memory_units 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-traits 0.2.5 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)" = "<none>"
@@ -1171,8 +1217,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sgx_unwind 0.0.1 (git+https://github.com/baidu/rust-sgx-sdk.git?rev=v1.0.7)" = "<none>"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
-"checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"

--- a/enigma-principal/enclave/Cargo.toml
+++ b/enigma-principal/enclave/Cargo.toml
@@ -13,7 +13,7 @@ enigma-tools-m = { path = "../../enigma-tools-m", default-features = false, feat
 enigma-types = { path = "../../enigma-types", default-features = false, features = ["sgx"] }
 enigma-crypto = { path = "../../enigma-crypto", default-features = false, features = ["sgx", "asymmetric"] }
 
-lazy_static = {version = "=1.2.0", features = ["spin_no_std"] }
+lazy_static = {version = "1.3.0", features = ["spin_no_std"] }
 ethabi = { git = "https://github.com/enigmampc/ethabi.git", rev = "sgx-v6.1.0-v1.0.7", default-features = false }
 ethereum-types = { git = "https://github.com/enigmampc/primitives.git", rev = "sgx-v0.4.0", default-features = false }
 rustc-hex = { version = "2.0", default-features = false }

--- a/enigma-principal/enclave/src/lib.rs
+++ b/enigma-principal/enclave/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(tool_lints)]
 #![feature(try_from)]
 #![feature(slice_concat_ext)]
-#![feature(int_to_from_bytes)]
+
 #![deny(unused_extern_crates)]
 
 extern crate enigma_crypto;

--- a/enigma-principal/enclave/src/lib.rs
+++ b/enigma-principal/enclave/src/lib.rs
@@ -2,9 +2,6 @@
 #![crate_type = "staticlib"]
 #![no_std]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
-#![feature(tool_lints)]
-#![feature(try_from)]
 #![feature(slice_concat_ext)]
 
 #![deny(unused_extern_crates)]

--- a/enigma-runtime-t/src/lib.rs
+++ b/enigma-runtime-t/src/lib.rs
@@ -15,7 +15,6 @@ extern crate enigma_crypto;
 extern crate enigma_types;
 extern crate json_patch;
 extern crate rmp_serde as rmps;
-#[macro_use]
 extern crate serde;
 extern crate wasmi;
 
@@ -221,7 +220,7 @@ impl Runtime {
     }
 
     fn treat_gas_underflow(&mut self, val: &Option<u64>) -> (bool, u64) {
-        let mut result = 0;
+        let result = 0;
         if let Some(v) = val {
             (false, *v)
         }
@@ -257,7 +256,7 @@ impl Runtime {
         } // If the new value is smaller than the old one, the gas should be returned
         else {
             let decrease_cost = (old_value_len - new_value_len).checked_mul(self.gas_costs.write_additional_byte);
-            let (underflow, val) = self.treat_gas_underflow(&decrease_cost);
+            let (underflow, _val) = self.treat_gas_underflow(&decrease_cost);
             if !underflow {
                 let tmp = self.gas_return.checked_add(decrease_cost.unwrap());
                 let (underflow, val) = self.treat_gas_underflow(&tmp);

--- a/enigma-tools-m/Cargo.toml
+++ b/enigma-tools-m/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 enigma-types = { path = "../enigma-types", default-features = false }
 enigma-crypto = { path = "../enigma-crypto", default-features = false, features = ["hash"] }
 
-log-derive = "0.2"
+log-derive = "0.3"
 log = { version = "0.4.6", default-features = false }
 failure = { version = "0.1", default-features = false, features = ["derive"] }
 etcommon-bigint = { version = "0.2", default-features = false, features = ["rlp"] }

--- a/enigma-tools-t/src/document_storage_t.rs
+++ b/enigma-tools-t/src/document_storage_t.rs
@@ -54,7 +54,7 @@ impl<T> SealedDocumentStorage<T> where
         let unsealed_result = sealed_data.unseal_data();
         match unsealed_result {
             Ok(unsealed_data) => {
-                let mut udata = unsealed_data.get_decrypt_txt();
+                let udata = unsealed_data.get_decrypt_txt();
                 Ok(Some(*udata))
             }
             Err(err) => {

--- a/enigma-tools-t/src/lib.rs
+++ b/enigma-tools-t/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 #![crate_type = "lib"]
-#![feature(core_intrinsics)]
-#![feature(try_from)]
 #![warn(unused_extern_crates)]
 
 extern crate enigma_types;
@@ -15,8 +13,6 @@ extern crate failure;
 extern crate json_patch;
 extern crate parity_wasm;
 extern crate pwasm_utils;
-#[macro_use]
-extern crate serde;
 extern crate sgx_tse;
 extern crate sgx_tseal;
 extern crate sgx_types;
@@ -37,12 +33,6 @@ pub mod document_storage_t; //TODO: Copy of storage_t with more generic naming c
 pub mod storage_t;
 pub mod esgx;
 
-#[cfg(debug_assertions)]
-#[no_mangle]
-pub extern "C" fn __assert_fail(__assertion: *const u8, __file: *const u8, __line: u32, __function: *const u8) -> ! {
-    use core::intrinsics::abort;
-    unsafe { abort() }
-}
 
 #[cfg(test)]
 mod tests {

--- a/enigma-tools-t/src/storage_t.rs
+++ b/enigma-tools-t/src/storage_t.rs
@@ -52,7 +52,7 @@ impl SecretKeyStorage {
         let unsealed_result = sealed_data.unseal_data();
         match unsealed_result {
             Ok(unsealed_data) => {
-                let mut udata = unsealed_data.get_decrypt_txt();
+                let udata = unsealed_data.get_decrypt_txt();
                 Some(*udata)
             }
             Err(err) => {

--- a/enigma-tools-u/Cargo.toml
+++ b/enigma-tools-u/Cargo.toml
@@ -17,20 +17,17 @@ etcommon-rlp = { version = "0.2.4", default-features = false }
 etcommon-bigint = "0.2"
 base64 = "0.10.0"
 openssl = "0.10"
-openssl-sys = "=0.9.44" # TODO: Remove after upgradding rustc.
+openssl-sys = "0.9"
 rustc-hex = "1.0.0" # 2.0.1?
 log = "0.4"
-log-derive = "0.2.0"
+log-derive = "0.3"
 simplelog = "0.5.3"
 dirs = "1.0.4"
-rustc-demangle = "=0.1.13"
-bitflags = "=1.0.4"
 
 # TODO: Change after a new version is released.
 # Add more transport layers via features if needed.
 web3 = { version  = "0.6", default-features = false, features=["http"]  }
 ethabi = "6.1.0"
-unicase = "=2.2.0"
 
 
 sgx_types = { git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7" }

--- a/enigma-tools-u/src/attestation_service/service.rs
+++ b/enigma-tools-u/src/attestation_service/service.rs
@@ -305,7 +305,7 @@ mod test {
         let quote = Quote::from_base64(&isv_enclave_quote).unwrap();
         let data = quote.report_body.report_data;
         let data_str = from_utf8(&data).unwrap();
-        assert_eq!(data_str.trim_right_matches("\x00"), "0x4e6dd28477d3cdcd3107507b61737aaa15916070");
+        assert_eq!(data_str.trim_end_matches("\x00"), "0x4e6dd28477d3cdcd3107507b61737aaa15916070");
     }
 
     #[test]

--- a/enigma-tools-u/src/esgx/general.rs
+++ b/enigma-tools-u/src/esgx/general.rs
@@ -8,7 +8,7 @@ use dirs;
 use failure::Error;
 
 pub fn storage_dir<P: AsRef<Path>>(dir_name: P) -> Result<PathBuf, Error> {
-    let mut path = dirs::home_dir().ok_or(format_err!("Missing HomeDir"))?;
+    let mut path = dirs::home_dir().ok_or_else(|| format_err!("Missing HomeDir"))?;
     println!("[+] Home dir is {}", path.display());
     path.push(dir_name);
     Ok(path)

--- a/enigma-tools-u/src/esgx/ocalls_u.rs
+++ b/enigma-tools-u/src/esgx/ocalls_u.rs
@@ -1,3 +1,5 @@
+#![allow(unused_attributes)]
+
 use std::{ptr, slice};
 use enigma_types::traits::SliceCPtr;
 use crate::esgx::general;

--- a/enigma-tools-u/src/esgx/ocalls_u.rs
+++ b/enigma-tools-u/src/esgx/ocalls_u.rs
@@ -1,5 +1,5 @@
 use std::{ptr, slice};
-use enigma_types::{RawPointer, traits::SliceCPtr};
+use enigma_types::traits::SliceCPtr;
 use crate::esgx::general;
 
 pub static ENCLAVE_DIR: &'static str = ".enigma";

--- a/enigma-tools-u/src/web3_utils/w3utils.rs
+++ b/enigma-tools-u/src/web3_utils/w3utils.rs
@@ -242,7 +242,7 @@ mod test {
     #[test]
     //#[ignore]
     fn test_deploy_dummy_contract() {
-        let (eloop, w3, accounts) = connect();
+        let (_eloop, w3, accounts) = connect();
         let contract = deploy_dummy(&w3, accounts[0]);
         // validate deployment
         // mine func add to a uint256=0 1 and returns it's value
@@ -260,7 +260,7 @@ mod test {
         let fake_input: Address = account.parse().expect("unable to parse account address");
         let fake_input = (fake_input.clone(), fake_input);
         // 2) connect to ethereum network
-        let (eloop, w3, accounts) = connect();
+        let (_eloop, w3, accounts) = connect();
         // 3) get mock of the deploy params
         let tx = get_deploy_params(accounts[0], "Enigma");
         // 4) deploy the contract
@@ -271,11 +271,11 @@ mod test {
     //#[ignore]
     fn test_deployed_contract() {
         // deploy the dummy contract
-        let (eloop, w3, accounts) = connect();
+        let (_eloop, w3, accounts) = connect();
         let contract = deploy_dummy(&w3, accounts[0]);
         // the deployed contract address
         let address = contract.address();
-        let (abi, bytecode) = get_contract(&String::from("Dummy"));
+        let (abi, _) = get_contract(&String::from("Dummy"));
         let contract = w3utils::deployed_contract(&w3, address, abi.as_bytes()).unwrap();
         let result = contract.query("mine", (), None, Options::default(), None);
         let param: U256 = result.wait().unwrap();

--- a/enigma-types/Cargo.toml
+++ b/enigma-types/Cargo.toml
@@ -12,8 +12,6 @@ arrayvec = { version = "0.4.10", default-features = false }
 serde_sgx = { package = "serde", git = "https://github.com/baidu/rust-sgx-sdk.git", rev = "v1.0.7", optional = true }
 serde_std = { package = "serde", version = "1.0", default-features = false }
 
-bitflags = "=1.0.4"
-
 [build-dependencies]
 cbindgen = "0.8"
 

--- a/enigma-types/src/lib.rs
+++ b/enigma-types/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
-#![feature(alloc)]
 #![deny(unused_extern_crates)]
 
 

--- a/enigma-types/src/types.rs
+++ b/enigma-types/src/types.rs
@@ -93,9 +93,10 @@ impl RawPointer {
 
 impl From<bool> for ResultStatus {
     fn from(i: bool) -> Self {
-        match i{
-            true => ResultStatus::Ok,
-            false => ResultStatus::Failure,
+        if i {
+            ResultStatus::Ok
+        } else {
+            ResultStatus::Failure
         }
     }
 }

--- a/examples/eng_wasm_contracts/erc20/Cargo.toml
+++ b/examples/eng_wasm_contracts/erc20/Cargo.toml
@@ -9,8 +9,6 @@ enigma-crypto = { path = "../../../enigma-crypto", default-features = false, fea
 rustc-hex = "2.0.1"
 serde = { version = "1.0", default-features = false, features=["serde_derive"] }
 
-bitflags = "=1.0.4"
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/eng_wasm_contracts/erc20/src/lib.rs
+++ b/examples/eng_wasm_contracts/erc20/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 
-#![feature(int_to_from_bytes)]
+
 
 extern crate eng_wasm;
 extern crate eng_wasm_derive;


### PR DESCRIPTION
Now that we updated the rustc version (#157) We can remove the version locks.
I did that and removed a lot of warnings we had for a long time.

@moriaab / @AvishaiW every part is organized into a commit to help reviewing (I don't rewrite the same stuff between commits (as long as I didn't screw up the interactive rebasing lol))