### PR TITLE
fixes #161

### DIFF
--- a/enigma-core/app/src/networking/ipc_listener.rs
+++ b/enigma-core/app/src/networking/ipc_listener.rs
@@ -218,7 +218,7 @@ pub(self) mod handling {
     pub fn get_contract(db: &DB, input: &str) -> ResponseResult {
         let address = ContractAddress::from_hex(&input)?;
         let data = db.get_contract(address).unwrap_or_default();
-        Ok(IpcResponse::GetContract { result: IpcResults::Bytecode(data.to_hex()) })
+        Ok(IpcResponse::GetContract { result: IpcResults::GetContract{address: address.to_hex(), bytecode: data.to_hex()} })
     }
 
     #[logfn(INFO)]

--- a/enigma-core/app/src/networking/messages.rs
+++ b/enigma-core/app/src/networking/messages.rs
@@ -31,7 +31,7 @@ pub enum IpcResponse {
     GetAllAddrs { result: IpcResults },
     GetDelta { result: IpcResults },
     GetDeltas { result: IpcResults },
-    GetContract { result: IpcResults },
+    GetContract { #[serde(flatten)] result: IpcResults },
     UpdateNewContract { address: String, result: IpcResults },
     UpdateDeltas { #[serde(flatten)] result: IpcResults },
     NewTaskEncryptionKey { #[serde(flatten)] result: IpcResults },
@@ -52,7 +52,11 @@ pub enum IpcResults {
     Addresses(Vec<String>),
     Delta(String),
     Deltas(Vec<IpcDelta>),
-    Bytecode(String),
+    #[serde(rename = "result")]
+    GetContract {
+        address: String,
+        bytecode: String,
+    },
     Status(Status),
     Tips(Vec<IpcDelta>),
     #[serde(rename = "result")]

--- a/enigma-core/app/tests/ipc_read_db_tests.rs
+++ b/enigma-core/app/tests/ipc_read_db_tests.rs
@@ -138,6 +138,8 @@ fn test_ipc_get_contract() {
     let type_accepted = res["type"].as_str().unwrap();
     let accepted_bytecode = res["result"]["bytecode"].as_str().unwrap();
     let deployed_bytecode = deployed_res["result"]["output"].as_str().unwrap();
+    let accepted_address = res["result"]["address"].as_str().unwrap().from_hex().unwrap();
+    assert_eq!(address.to_vec(), accepted_address);
     assert_eq!(type_accepted, type_msg);
     assert_eq!(deployed_bytecode, accepted_bytecode);
 }


### PR DESCRIPTION
modifies the getContract response according to the [ipc messages document](https://github.com/enigmampc/enigma-p2p/blob/develop/docs/IPC_MESSAGES.md#getcontract-message)