### PR TITLE
MAINT: updated simple_addition contract

### DIFF
--- a/examples/eng_wasm_contracts/simple_addition/src/lib.rs
+++ b/examples/eng_wasm_contracts/simple_addition/src/lib.rs
@@ -2,10 +2,6 @@
 // features of its host system: threads, networking, heap allocation, and others. SGX environments
 // do not have these features, so we tell Rust that we don’t want to use the standard library
 #![no_std]
-#![allow(unused_attributes)] // TODO: Remove on future nightly https://github.com/rust-lang/rust/issues/60050
-
-
-
 
 // The eng_wasm crate allows to use the Enigma runtime, which provides:
 //     - Read from state      read_state!(key)        


### PR DESCRIPTION
Maintenance commit. As per the comment on the removed line, needs to be removed as nightly was already updated. I am using this for `enigmampc/discovery-cli` as I believe it's the simpler contract we have, and I would like to pull it from here directly, as otherwise (until I submitted this PR) I was keeping a local copy in another repo that is redundant.