### PR TITLE
MAINT: adj verbosity after #179

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -108,7 +108,6 @@ steps:
         from_secret: password
     commands:
       - cd discovery-docker-network/enigma-core
-      - sed -i "s/-vv/-v/" start_core.bash && sed -i "s/-vv/-v/" start_km.bash
       - echo $PASSWORD | docker login -u $USERNAME --password-stdin
       - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
       - docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .


### PR DESCRIPTION
Adjusting verbosity of the `core` container after #179, which had been reduced a level because the Travis CI builds were failing because of too much output. This seems the right level of verbosity now, if the Travis CI builds fail, we will adjust it elsewhere (and yes it's Travis when running the integration tests for the `contract` and `p2p`, and not Drone where the tests for this repo run).