### PR TITLE
DEV: removing no_mangle

### DIFF
--- a/examples/eng_wasm_contracts/contract_with_eth_calls/src/lib.rs
+++ b/examples/eng_wasm_contracts/contract_with_eth_calls/src/lib.rs
@@ -28,7 +28,6 @@ impl ContractInterface for Contract {
     /// Writes value to state and reads it.
     /// As a temporary solution the value is converted to a stream of bytes.
     /// Later as part of runtime there will be created a macros for writing and reading any type.
-    #[no_mangle]
     fn write() {
         let mut a = String::new();
         a.push_str("157");
@@ -40,18 +39,15 @@ impl ContractInterface for Contract {
         assert_eq!(read_val, a);
     }
 
-    #[no_mangle]
     fn print_test(x: U256, y: U256) {
         eprint!("{:?} {:?}", x.as_u64(), y.as_u64());
     }
 
-    #[no_mangle]
     fn test() {
         let c = EthContract::new("0x123f681646d4a755815f9cb19e1acc8565a0c2ac");
         c.getBryn(U256::from(1), Vec::new());
     }
 
-    #[no_mangle]
     fn construct(){
         let mut a = String::new();
         a.push_str("69");

--- a/examples/eng_wasm_contracts/erc20/src/lib.rs
+++ b/examples/eng_wasm_contracts/erc20/src/lib.rs
@@ -102,7 +102,6 @@ impl Contract {
 
 impl Erc20Interface for Contract {
 
-    #[no_mangle]
     fn construct(owner_of_the_contract: H256, total_supply: U256) {
         let mut user_addr = Self::get_user(owner_of_the_contract);
         user_addr.balance = total_supply;
@@ -113,7 +112,6 @@ impl Erc20Interface for Contract {
         );
     }
 
-    #[no_mangle]
     fn mint(owner: H256, addr: H256, tokens: U256, sig: Vec<u8>) {
         // verify the owner is the one who is minting.
         let contract_owner: H256 = read_state!(CONTRACT_OWNER).unwrap();
@@ -128,24 +126,20 @@ impl Erc20Interface for Contract {
         write_state!(&addr.to_hex::<String>() => user_addr, TOTAL_SUPPLY => total_supply + tokens);
     }
 
-    #[no_mangle]
     fn total_supply() -> U256 {
         read_state!(TOTAL_SUPPLY).unwrap_or_default()
     }
 
-    #[no_mangle]
     fn balance_of(token_owner: H256) -> U256 {
         let user: User = Self::get_user(token_owner);
         user.balance
     }
 
-    #[no_mangle]
     fn allowance(owner: H256, spender: H256) -> U256 {
         let user: User = Self::get_user(owner);
         user.get_approved(spender)
     }
 
-    #[no_mangle]
     fn transfer(from: H256, to: H256, tokens: U256, sig: Vec<u8>) {
         assert!(Self::verify(from.clone(), to.clone(), tokens, sig));
         let mut from_user : User = Self::get_user(from);
@@ -160,7 +154,6 @@ impl Erc20Interface for Contract {
         write_state!(&from.to_hex::<String>() => from_user, &to.to_hex::<String>() => to_user);
     }
 
-    #[no_mangle]
     fn approve(token_owner: H256, spender: H256, tokens: U256, sig: Vec<u8>) {
         assert!(Self::verify(token_owner.clone(), spender.clone(), tokens, sig));
         let mut owner_user : User = Self::get_user(token_owner);
@@ -170,7 +163,6 @@ impl Erc20Interface for Contract {
         write_state!(&token_owner.to_hex::<String>() => owner_user);
     }
 
-    #[no_mangle]
     fn transfer_from(owner: H256, spender: H256, to: H256, tokens: U256, sig: Vec<u8>) {
         assert!(Self::verify(spender.clone(), to.clone(), tokens, sig));
         let mut owner_user : User = Self::get_user(owner);

--- a/examples/eng_wasm_contracts/millionaires_problem_demo/src/lib.rs
+++ b/examples/eng_wasm_contracts/millionaires_problem_demo/src/lib.rs
@@ -47,7 +47,6 @@ impl Contract {
 
 impl ContractInterface for Contract {
     // Add millionaire with 32-byte hash type for address and 32-byte uint for net worth
-    #[no_mangle]
     fn add_millionaire(address: H256, net_worth: U256) {
         // Read state to get vector of Millionaires
         let mut millionaires = Self::get_millionaires();
@@ -61,7 +60,6 @@ impl ContractInterface for Contract {
     }
 
     // Compute the richest millionaire by returning the 32-byte hash type for the address
-    #[no_mangle]
     fn compute_richest() -> H256 {
         // Read state to get vector of Millionaires and obtain the struct corresponding to the
         // richest millionaire by net worth

--- a/examples/eng_wasm_contracts/simple_addition/src/lib.rs
+++ b/examples/eng_wasm_contracts/simple_addition/src/lib.rs
@@ -33,11 +33,8 @@ pub trait ContractInterface{
 
 // The implementation of the exported ESC functions should be defined in the trait implementation 
 // for a new struct. 
-// #[no_mangle] modifier is required before each function to turn off Rust's name mangling, so that
-// it is easier to link to. Sets the symbol for this item to its identifier.
 pub struct Contract;
 impl ContractInterface for Contract {
-    #[no_mangle]
     fn addition(x: U256, y: U256) -> U256 {
         write_state!("code"=> (x+y).as_u32());
         x + y

--- a/examples/eng_wasm_contracts/simple_calculator/src/lib.rs
+++ b/examples/eng_wasm_contracts/simple_calculator/src/lib.rs
@@ -19,7 +19,6 @@ pub trait ContractInterface{
 
 pub struct Contract;
 impl ContractInterface for Contract {
-    #[no_mangle]
     fn add(a: U256, b: U256) -> U256 {
         let res = a.checked_add(b);
         match res {
@@ -28,7 +27,6 @@ impl ContractInterface for Contract {
         }
     }
 
-    #[no_mangle]
     fn sub(a: U256, b: U256) -> U256 {
         let res = a.checked_sub(b);
         match res {
@@ -37,7 +35,6 @@ impl ContractInterface for Contract {
         }
     }
 
-    #[no_mangle]
     fn mul(a: U256, b: U256) -> U256 {
         let res = a.checked_mul(b);
         match res {
@@ -46,7 +43,6 @@ impl ContractInterface for Contract {
         }
     }
 
-    #[no_mangle]
     fn div(a: U256, b: U256) -> U256 {
         let res = a.checked_div(b);
         match res {

--- a/examples/eng_wasm_contracts/simplest/src/lib.rs
+++ b/examples/eng_wasm_contracts/simplest/src/lib.rs
@@ -47,7 +47,6 @@ impl ContractInterface for Contract {
     /// Writes value to state and reads it.
     /// As a temporary solution the value is converted to a stream of bytes.
     /// Later as part of runtime there will be created a macros for writing and reading any type.
-    #[no_mangle]
     fn write() -> Vec<u8> {
         let mut a = String::new();
         a.push_str("157");
@@ -59,7 +58,6 @@ impl ContractInterface for Contract {
         read_val.as_bytes().to_vec()
     }
 
-    #[no_mangle]
     fn check_address(addr: H256) -> H256{
         write_state!("addr" => addr);
         let read_val: H256 = read_state!("addr").unwrap_or_default();
@@ -67,7 +65,6 @@ impl ContractInterface for Contract {
         read_val
     }
 
-    #[no_mangle]
     fn check_addresses(addr1: H256, addr2: H256) -> Vec<H256> {
         write_state!("addr1" => addr1);
         write_state!("addr2" => addr2);
@@ -84,7 +81,6 @@ impl ContractInterface for Contract {
     }
 
     // tests the random service
-    #[no_mangle]
     fn choose_rand_color() -> Vec<u8> {
         let mut colors = Vec::new();
         colors.extend(["green", "yellow", "red", "blue", "white", "black", "orange", "purple"].iter().cloned());
@@ -97,32 +93,27 @@ impl ContractInterface for Contract {
     }
 
     // tests the shuffle service on a simple array
-    #[no_mangle]
     fn get_scrambled_vec() {
         let mut nums: [u8; 10] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         Self::shuffle(&mut nums);
         unsafe {external::ret(nums.as_ptr(), nums.len() as u32)};
     }
 
-    #[no_mangle]
     fn addition(x: U256, y: U256) -> U256 {
         let sum: u64 = x.as_u64() + y.as_u64();
         write_state!("curr_sum" => sum);
         sum.into()
     }
 
-    #[no_mangle]
     fn get_last_sum() -> U256 {
         let sum: u64 = read_state!("curr_sum").unwrap_or_default();
         sum.into()
     }
 
-    #[no_mangle]
     fn print_test(x: U256, y: U256) {
         eprint!("{:?} {:?}", x.as_u64(), y.as_u64());
     }
 
-    #[no_mangle]
     fn construct(param: U256){
         write_state!("1" => param.as_u64());
     }

--- a/examples/eng_wasm_contracts/voting_demo/src/lib.rs
+++ b/examples/eng_wasm_contracts/voting_demo/src/lib.rs
@@ -49,14 +49,12 @@ impl Contract {
 
 impl ContractInterface for Contract {
     // Constructor function that takes in VotingETH ethereum contract address
-    #[no_mangle]
     fn construct(voting_eth_addr: H160) {
         let voting_eth_addr_str: String = voting_eth_addr.to_hex();
         write_state!(VOTING_ETH_ADDR => voting_eth_addr_str);
     }
 
     // Cast vote function that takes poll ID, voter address, and vote - calls back to ETH
-    #[no_mangle]
     fn cast_vote(poll_id: U256, voter: H256, vote: U256) {
         let mut polls = Self::get_polls();
         {
@@ -72,7 +70,6 @@ impl ContractInterface for Contract {
     }
 
     // Tally poll function that takes poll ID - calls back to ETH
-    #[no_mangle]
     fn tally_poll(poll_id: U256) {
         let polls = Self::get_polls();
         let mut tallied_quorum: U256 = U256::zero();


### PR DESCRIPTION
`no_mangle` directive does not affect the functionality of the program. The secret contract functions are addressed by a procedural macro `pub_interface` by their names. Compilation names does not matter.