### PR TITLE
TST: moving from 1 to 3 nodes in integrationTests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ steps:
         docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache . &&
         docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache . &&
         cd ..
-      - NODES=3 docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml --scale core=$NODES --scale p2p=$NODES up --exit-code-from client
+      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
     privileged: true
     volumes:
       - name: sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ steps:
         docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache . &&
         docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache . &&
         cd ..
-      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --exit-code-from client
+      - NODES=3 docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml --scale core=$NODES --scale p2p=$NODES up --exit-code-from client
     privileged: true
     volumes:
       - name: sock

--- a/examples/eng_wasm_contracts/flip_coin/src/lib.rs
+++ b/examples/eng_wasm_contracts/flip_coin/src/lib.rs
@@ -12,7 +12,7 @@ pub trait ContractInterface{
     fn flip() -> bool;
 
     /// Player 1 commits to a coin value
-    fn commit(bool);
+    fn commit(commitment: bool);
 
     /// Player 2 guesses the value that player 1 was committed to. The commitment is removed.
     /// True is returned on successful guess.

--- a/examples/eng_wasm_contracts/simple_addition/src/lib.rs
+++ b/examples/eng_wasm_contracts/simple_addition/src/lib.rs
@@ -20,7 +20,7 @@ use eng_wasm_derive::pub_interface;
 // For contract-exposed functions, declare such functions under the following public trait:
 #[pub_interface]
 pub trait ContractInterface{
-    fn addition(U256, U256) -> U256 ;
+    fn addition(x: U256, y: U256) -> U256 ;
 }
 
 // The implementation of the exported ESC functions should be defined in the trait implementation 


### PR DESCRIPTION
Increasing from `NODES=1` to `NODES=3` to run the integration tests for increased robustness of said tests.

Analogous to:

- enigmampc/discovery-docker-network#39
- enigmampc/enigma-p2p#233
- enigmampc/enigma-contract#151