### PR TITLE
specified version for path dependency in eng-wasm/derive

### DIFF
--- a/eng-wasm/derive/Cargo.toml
+++ b/eng-wasm/derive/Cargo.toml
@@ -23,7 +23,7 @@ tiny-keccak = "1.4"
 
 [dev-dependencies]
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-eng-wasm = { path = '..' }
+eng-wasm = { path = '..', version = "0.1" }
 
 [[example]]
 name = 'struct-impl'


### PR DESCRIPTION
This is done because crates.io requires a version specification for path dependencies.

```
error: all path dependencies must have a version specified when publishing.
dependency `eng-wasm` does not specify a version
```