### PR TITLE
Retry Attestation calls at registration

### DIFF
--- a/enigma-core/app/src/cli.rs
+++ b/enigma-core/app/src/cli.rs
@@ -26,4 +26,7 @@ pub struct Opt {
     /// Select a port for the enigma-p2p listener
     #[structopt(long = "port", short = "p", default_value = "5552")]
     pub port: u16,
+    /// Specify the number of Attestation call retries when failing
+    #[structopt(long = "retries", short = "r", default_value = "10")]
+    pub retries: u32,
 }

--- a/enigma-core/app/src/main.rs
+++ b/enigma-core/app/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
     let server = IpcListener::new(&format!("tcp://*:{}", opt.port));
 
     server
-        .run(move |multi| ipc_listener::handle_message(&mut db, multi, &opt.spid, eid))
+        .run(move |multi| ipc_listener::handle_message(&mut db, multi, &opt.spid, eid, opt.retries))
         .wait()
         .unwrap();
 }

--- a/enigma-core/app/tests/integration_utils/mod.rs
+++ b/enigma-core/app/tests/integration_utils/mod.rs
@@ -49,8 +49,9 @@ pub fn run_core(port: &'static str) {
         let (mut db, _datadir) = create_test_db();
         let server = IpcListener::new(&format!("tcp://*:{}", port));
         let spid = "B0335FD3BC1CCA8F804EB98A6420592D";
+        let retries = 10;
         server
-            .run(move |multi| ipc_listener::handle_message(&mut db, multi, spid, eid))
+            .run(move |multi| ipc_listener::handle_message(&mut db, multi, spid, eid, retries))
             .wait()
             .unwrap();
 

--- a/enigma-principal/app/src/boot_network/principal_manager.rs
+++ b/enigma-principal/app/src/boot_network/principal_manager.rs
@@ -415,5 +415,6 @@ mod test {
         let config = PrincipalConfig::load_config("this is not a path").unwrap();
         assert_eq!(config.polling_interval, 1);
         assert_eq!(config.http_port, 3040);
+        assert_eq!(config.attestation_retries, 11);
     }
 }

--- a/enigma-principal/app/src/boot_network/principal_manager.rs
+++ b/enigma-principal/app/src/boot_network/principal_manager.rs
@@ -39,6 +39,7 @@ pub struct PrincipalConfig {
     pub max_epochs: Option<usize>,
     pub spid: String,
     pub attestation_service_url: String,
+    pub attestation_retries: u32,
     pub http_port: u16,
     pub confirmations: u64,
 }
@@ -65,7 +66,7 @@ pub struct PrincipalManager {
 
 impl ReportManager {
     pub fn new(config: PrincipalConfig, eid: sgx_enclave_id_t) -> Result<Self, Error> {
-        let as_service = service::AttestationService::new(&config.attestation_service_url);
+        let as_service = service::AttestationService::new_with_retries(&config.attestation_service_url, config.attestation_retries);
         Ok(ReportManager { config, as_service, eid })
     }
 
@@ -408,6 +409,7 @@ mod test {
         env::set_var("MAX_EPOCHS","10");
         env::set_var("SPID", "B0335FD3BC1CCA8F804EB98A6420592D");
         env::set_var("ATTESTATION_SERVICE_URL", "https://sgx.enigma.co/api");
+        env::set_var("ATTESTATION_RETRIES", "11");
         env::set_var("HTTP_PORT","3040");
         env::set_var("CONFIRMATIONS","0");
         let config = PrincipalConfig::load_config("this is not a path").unwrap();

--- a/enigma-principal/app/tests/principal_node/config/principal_test_config.json
+++ b/enigma-principal/app/tests/principal_node/config/principal_test_config.json
@@ -12,6 +12,7 @@
     "max_epochs": 10,
     "spid": "B0335FD3BC1CCA8F804EB98A6420592D",
     "attestation_service_url": "https://sgx.enigma.co/api",
+    "attestation_retries": 10,
     "http_port": 3040,
     "confirmations": 0
 }

--- a/enigma-tools-u/src/attestation_service/service.rs
+++ b/enigma-tools-u/src/attestation_service/service.rs
@@ -142,13 +142,15 @@ impl AttestationService {
         let response_str = res.text()?;
         let json_response: Value = serde_json::from_str(response_str.as_str())?;
 
-        if res.status().is_success() {
+        if res.status().is_success() && !json_response["error"].is_object() {
             // parse the Json object into an ASResponse struct
             let response: ASResponse = self.unwrap_response(&json_response);
             Ok(response)
         }
         else {
-            let message = format!("[-] AttestationService: An Error occurred. Status code: {:?}", res.status());
+            let message = format!("[-] AttestationService: An Error occurred. \
+                                            Status code: {:?}\nError response: {:?}",
+                                            res.status(), json_response["error"]["message"].as_str());
             Err(errors::AttestationServiceErr { message }.into())
         }
     }

--- a/enigma-tools-u/src/attestation_service/service.rs
+++ b/enigma-tools-u/src/attestation_service/service.rs
@@ -320,6 +320,7 @@ mod test {
     use crate::attestation_service::{self, service::*};
     use std::str::from_utf8;
     use hex::FromHex;
+    use common_u::errors::AttestationServiceErr;
 
     // this unit-test is for the attestation service
     // it uses a hardcoded quote that is validated
@@ -338,6 +339,29 @@ mod test {
         assert_eq!(true, as_response.result.validate);
         assert_eq!("2.0", as_response.jsonrpc);
     }
+
+    // Run the same test but with no option of retries
+    #[test]
+    fn test_get_response_attestation_service_no_retries() {
+        // build a request with an initialized amount of 0 retries
+        let service: AttestationService = AttestationService::new_with_retries(attestation_service::constants::ATTESTATION_SERVICE_URL, 0);
+        let quote = String::from("AgAAANoKAAAHAAYAAAAAALAzX9O8HMqPgE65imQgWS3bL6zst0H4QfxKAKurXXnVBAX/////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAIzp3AzhlP03bwcSpF+o5J3dlTq2zu0T03uf7PbnLtMYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACD1xnnferKFHD2uvYqTXdDA8iZ22kCD5xw7h38CMfOngAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9sUtS1/Vn5lvk3Mxh+eX0AOjdoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqAIAADM2OO98uEjJQLRmzAvAqO4nirzimAHK0PjdgI8MT0xKDy/Paohf208N04YWgzl4kOjrG0X/T8LUphwzn3qB7XkycWqDO9RsLbNIpKRiVBIttztbn0/kxcwo6p54OeOLfhFbxaTn0wkzEYJhGWVR+j6IUGxubDwinf0fO+2vPu20kW1NzSV/Le8fyYzC4v5sIblVW8VZESsbuFd+bFbbcNzco9cH6cNI68FMkeMHoZF/Z4HvP7DR2sIiLnmYcavDbTlzG7OwaTDNcTCNfKsKReK76TRtu+m018QArsRTdrAwx7gZY2788RBpn0veSkU+v9QxNnZmqfpMolAXdu3ksQul4R8bzQ8HoiRkQvedCY8K+5j3GLvDjLCUgB4JP8Vhtt6KjABRO5o4+s3Uj2gBAABJIOqpxIvbG5zmizV7zUe4jAJQoPVM3jtcxXwU9PH5saXiCPHBpTEBpK/2r/5bUnIIBkshRbQ8/kP6/lLhEOu3Fkfh7UMMoizPO8uGQimLBGwbAFyAgU4G8TGeUbYWEGuRRJoKDoclzm9edJZ7mApMlmiT9t2VMLMsg7l49sO1T1TtgK/zpwwLvr2f4a/vmkJWviOcIRimFD+V20xw+EMXYl8Aj4x4Rw62+oiQe0mKvh3K4gXIamejnQHZ/Mrbeh8ai0n1J+GMeKFxxSkeytGZVrT+a75WjLAcJtt5QAU3Em1ELsWLUVUI58mLTe/u+hsjTlWizXAruElzhCIijvR96aHc+lzd/a+EmsQ4mI/mWPxqdoUciznhG4VlxNAhXSw8zn77k8m+1GaBSxvAUDwFOf/V3KcQUYp5Cswo1MD4t26Rn5LBqF1I0I27d/BHD+KUwl7W5doG4Ec6egnoofkSTUnjI3G+9btxIVV2nYWzfXauZzseiZQn");
+        let as_response = service.get_report(quote).unwrap();
+
+        assert_eq!(true, as_response.result.validate);
+        assert_eq!("2.0", as_response.jsonrpc);
+    }
+
+    #[test]
+    fn test_response_attestation_service_failure_no_retries() {
+        // build a faulty request
+        let service: AttestationService = AttestationService::new_with_retries(attestation_service::constants::ATTESTATION_SERVICE_URL, 0);
+        let quote = String::from("Wrong quote");
+        let as_response = service.get_report(quote.clone());
+        // if it's able to do the downcast, we got the correct error
+        assert!(as_response.unwrap_err().downcast::<AttestationServiceErr>().is_ok());
+    }
+
     // get rlp_encoded Vec<u8> that contains the bytes array for worker registration in the enigma smart contract.
     #[test]
     fn test_get_response_attestation_service_rlp_encoded() {


### PR DESCRIPTION
This PR adds a retry loop for getting the attestation report from the proxy server. we can get the number of retries from the user or run 10 by default