### PR TITLE
MAINT: builds match branches across repos

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -99,7 +99,7 @@ steps:
           export TAG=latest;
           docker-compose pull
         else
-          if ! (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CONTRACT )); then
+          if [ $MATCHING_BRANCH_P2P -eq 0 ] &&  [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
             export TAG=develop;
             sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
             docker-compose pull
@@ -127,7 +127,10 @@ steps:
         docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache . &&
         docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache . &&
         cd ..
-      - export NODES=3 && docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client
+      - export NODES=3 
+      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
+      - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
+      - if [ $RESULT -ne 0 ]; exit 1; fi
     privileged: true
     volumes:
       - name: sock
@@ -162,24 +165,6 @@ steps:
     volumes:
       - name: sock
         path: /var/run/docker.sock
-
-  - name: cleanup
-    image: enigmampc/docker-client
-    depends_on:
-      - integration
-    when:
-      branch:
-          exclude:
-            - master
-            - develop
-    commands:
-      - |
-        if (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CONTRACT )); then
-          docker rmi enigmampc/enigma_core_hw:$TAG
-          docker rmi enigmampc/enigma_km_hw:$TAG
-          docker rmi enigmampc/enigma_contract:$TAG
-          docker rmi enigmampc/enigma_p2p:$TAG
-        fi
 
 volumes:
   - name: isgx

--- a/.drone.yml
+++ b/.drone.yml
@@ -101,34 +101,26 @@ steps:
       - export DOCKER_TAG=core_${DRONE_BUILD_NUMBER}
       - sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${DOCKER_TAG}/" .env;
       - |
-        if [[ "${DRONE_BRANCH}" == "master" ]]; then
-          docker pull enigmampc/enigma_contract:latest
-          docker pull enigmampc/enigma_p2p:latest
-          docker tag enigmampc/enigma_contract:latest enigmampc/enigma_contract:$DOCKER_TAG
-          docker tag enigmampc/enigma_p2p:latest enigmampc/enigma_p2p:$DOCKER_TAG
-        else
-          if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
-            docker pull enigmampc/enigma_contract:develop
-            docker pull enigmampc/enigma_p2p:develop
-            docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
-            docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
+        /bin/bash -c '
+        declare -a PROJECTS=(p2p contract)
+        declare -A DOCKER_IMAGES=([p2p]=enigma_p2p [contract]=enigma_contract)
+        declare -A GIT_BRANCH_ARG=([p2p]=GIT_BRANCH_P2P [contract]=GIT_BRANCH_CONTRACT)
+        declare -A PROJECT_DIRECTORY=([p2p]=enigma-p2p [contract]=enigma-contract)
+        declare -A PROJECT_BRANCH_FOUND=([p2p]=$MATCHING_BRANCH_P2P [contract]=$MATCHING_BRANCH_CONTRACT)
+        for project in $${PROJECTS[@]}; do
+          DOCKER_IMAGE="enigmampc/$${DOCKER_IMAGES[$project]}"
+          if [[ "$DRONE_BRANCH" == "master" ]]; then
+            docker pull "$DOCKER_IMAGE:latest"
+            docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$DOCKER_TAG"
+          elif [ "$${PROJECT_BRANCH_FOUND[$project]}" -eq 0 ]; then
+            docker pull "$DOCKER_IMAGE:develop"
+            docker tag "$DOCKER_IMAGE:develop" "$DOCKER_IMAGE:$DOCKER_TAG"
           else
-            if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
-              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
-              docker pull enigmampc/enigma_contract:develop
-              docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
-            else
-              if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CONTRACT -eq 1 ]; then
-                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
-                docker pull enigmampc/enigma_p2p:develop
-                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
-              else
-                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
-                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
-              fi
-            fi
+            cd "$${PROJECT_DIRECTORY[$project]}"
+            docker build --build-arg "$${GIT_BRANCH_ARG[$project]}=${DRONE_BRANCH}" -t "$DOCKER_IMAGE:$DOCKER_TAG" --no-cache .
+            cd ..
           fi
-        fi
+        done'
       - |
         cd enigma-core &&
         docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache . &&

--- a/.drone.yml
+++ b/.drone.yml
@@ -92,9 +92,36 @@ steps:
       - git clone https://github.com/enigmampc/discovery-docker-network.git
       - cd discovery-docker-network && cp .env-template .env
       - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
-      - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-      - if [[ $TAG == "develop" ]]; then sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env; fi
-      - docker-compose pull
+      - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
+      - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
+      - |
+        if [[ ${DRONE_BRANCH} == "master" ]]; then
+          export TAG=latest;
+          docker-compose pull
+        else
+          if ! (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CONTRACT )); then
+            export TAG=develop;
+            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
+            docker-compose pull
+          else
+            export TAG=$DRONE_BRANCH;
+            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
+            if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
+              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+              docker pull enigmampc/enigma_contract:develop
+              docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+            else
+              if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CONTRACT -eq 1 ]; then
+                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+                docker pull enigmampc/enigma_p2p:develop
+                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$TAG
+              else
+                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+              fi
+            fi
+          fi
+        fi
       - |
         cd enigma-core &&
         docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache . &&
@@ -135,6 +162,19 @@ steps:
     volumes:
       - name: sock
         path: /var/run/docker.sock
+
+  - name: cleanup
+    image: enigmampc/docker-client
+    depends_on:
+      - integration
+    commands:
+      - |
+        if (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CONTRACT )); then
+          docker rmi enigmampc/enigma_core_hw:$TAG || true
+          docker rmi enigmampc/enigma_km_hw:$TAG || true
+          docker rmi enigmampc/enigma_contract:$TAG || true
+          docker rmi enigmampc/enigma_p2p:$TAG || true
+        fi
 
 volumes:
   - name: isgx

--- a/.drone.yml
+++ b/.drone.yml
@@ -95,7 +95,7 @@ steps:
       - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
       - |
-        if [[ ${DRONE_BRANCH} == "master" ]]; then
+        if [[ "${DRONE_BRANCH}" == "master" ]]; then
           export TAG=latest;
           docker-compose pull
         else
@@ -167,13 +167,18 @@ steps:
     image: enigmampc/docker-client
     depends_on:
       - integration
+    when:
+      branch:
+          exclude:
+            - master
+            - develop
     commands:
       - |
         if (( $MATCHING_BRANCH_P2P + $MATCHING_BRANCH_CONTRACT )); then
-          docker rmi enigmampc/enigma_core_hw:$TAG || true
-          docker rmi enigmampc/enigma_km_hw:$TAG || true
-          docker rmi enigmampc/enigma_contract:$TAG || true
-          docker rmi enigmampc/enigma_p2p:$TAG || true
+          docker rmi enigmampc/enigma_core_hw:$TAG
+          docker rmi enigmampc/enigma_km_hw:$TAG
+          docker rmi enigmampc/enigma_contract:$TAG
+          docker rmi enigmampc/enigma_p2p:$TAG
         fi
 
 volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,8 +7,8 @@ steps:
 
   - name: core
     image: enigmampc/enigma-core:0.0.10
-    depends_on: [clone]
     privileged: true
+    depends_on: [clone]
     commands:
       - LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service
       - . /opt/sgxsdk/environment && . /root/.cargo/env
@@ -21,8 +21,8 @@ steps:
 
   - name: principal
     image: enigmampc/enigma-core:0.0.10
-    depends_on: [clone]
     privileged: true
+    depends_on: [clone]
     commands:
       - LD_LIBRARY_PATH=/opt/intel/libsgx-enclave-common/aesm /opt/intel/libsgx-enclave-common/aesm/aesm_service
       - . /opt/sgxsdk/environment && . /root/.cargo/env
@@ -85,59 +85,63 @@ steps:
 
   - name: integration
     image: enigmampc/docker-client
+    privileged: true
     depends_on:
       - core
       - principal
+    volumes:
+      - name: sock
+        path: /var/run/docker.sock
     commands:
       - git clone https://github.com/enigmampc/discovery-docker-network.git
       - cd discovery-docker-network && cp .env-template .env
       - sed -i "s/COMPOSE_PROJECT_NAME=.*/COMPOSE_PROJECT_NAME=enigma_${DRONE_BUILD_NUMBER}/" .env
       - export MATCHING_BRANCH_P2P="$(git ls-remote --heads https://github.com/enigmampc/enigma-p2p.git ${DRONE_BRANCH} | wc -l)"
       - export MATCHING_BRANCH_CONTRACT="$(git ls-remote --heads https://github.com/enigmampc/enigma-contract.git ${DRONE_BRANCH} | wc -l)"
+      - export DOCKER_TAG=core_${DRONE_BUILD_NUMBER}
+      - sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${DOCKER_TAG}/" .env;
       - |
         if [[ "${DRONE_BRANCH}" == "master" ]]; then
-          export TAG=latest;
-          docker-compose pull
+          docker pull enigmampc/enigma_contract:latest
+          docker pull enigmampc/enigma_p2p:latest
+          docker tag enigmampc/enigma_contract:latest enigmampc/enigma_contract:$DOCKER_TAG
+          docker tag enigmampc/enigma_p2p:latest enigmampc/enigma_p2p:$DOCKER_TAG
         else
-          if [ $MATCHING_BRANCH_P2P -eq 0 ] &&  [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
-            export TAG=develop;
-            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=develop/" .env;
-            docker-compose pull
+          if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
+            docker pull enigmampc/enigma_contract:develop
+            docker pull enigmampc/enigma_p2p:develop
+            docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
+            docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
           else
-            export TAG=$DRONE_BRANCH;
-            sed -i "s/DOCKER_TAG=latest/DOCKER_TAG=${TAG}/" .env;
             if [ $MATCHING_BRANCH_P2P -eq 1 ] && [ $MATCHING_BRANCH_CONTRACT -eq 0 ]; then
-              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
+              cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
               docker pull enigmampc/enigma_contract:develop
-              docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$TAG
+              docker tag enigmampc/enigma_contract:develop enigmampc/enigma_contract:$DOCKER_TAG
             else
               if [ $MATCHING_BRANCH_P2P -eq 0 ] && [ $MATCHING_BRANCH_CONTRACT -eq 1 ]; then
-                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
                 docker pull enigmampc/enigma_p2p:develop
-                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$TAG
+                docker tag enigmampc/enigma_p2p:develop enigmampc/enigma_p2p:$DOCKER_TAG
               else
-                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$TAG --no-cache . && cd ..
-                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$TAG --no-cache . && cd ..
+                cd enigma-p2p && docker build --build-arg GIT_BRANCH_P2P=${DRONE_BRANCH} -t enigmampc/enigma_p2p:$DOCKER_TAG --no-cache . && cd ..
+                cd enigma-contract && docker build --build-arg GIT_BRANCH_CONTRACT=${DRONE_BRANCH} -t enigmampc/enigma_contract:$DOCKER_TAG --no-cache . && cd ..
               fi
             fi
           fi
         fi
       - |
         cd enigma-core &&
-        docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache . &&
-        docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache . &&
+        docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache . &&
+        docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache . &&
         cd ..
-      - export NODES=3 
+      - export NODES=3
       - docker-compose -f docker-compose.yml -f docker-compose.hw.yml -f docker-compose.test.yml up --scale core=$NODES --scale p2p=$NODES --exit-code-from client && export RESULT=$? || export RESULT=$?
-      - if [[ "${DRONE_BRANCH}" == "$TAG" ]]; then docker-compose down -v --rmi all; else docker-compose down -v; fi
-      - if [ $RESULT -ne 0 ]; exit 1; fi
-    privileged: true
-    volumes:
-      - name: sock
-        path: /var/run/docker.sock
+      - docker-compose -f docker-compose.yml -f docker-compose.hw.yml down -v --rmi all || true
+      - if [ $RESULT -ne 0 ]; then exit 1; fi
 
   - name: deploy
     image: enigmampc/docker-client
+    privileged: true
     depends_on:
       - integration
     when:
@@ -149,22 +153,21 @@ steps:
         from_secret: username
       PASSWORD:
         from_secret: password
-    commands:
-      - cd discovery-docker-network/enigma-core
-      - echo $PASSWORD | docker login -u $USERNAME --password-stdin
-      - if [[ ${DRONE_BRANCH} == "master" ]]; then export TAG=latest; else export TAG=develop; fi
-      - docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$TAG --no-cache .
-      - docker push enigmampc/enigma_core_hw:$TAG
-      - docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$TAG --no-cache .
-      - docker push enigmampc/enigma_km_hw:$TAG
-      - docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$TAG --no-cache .
-      - docker push enigmampc/enigma_core_sw:$TAG
-      - docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$TAG --no-cache .
-      - docker push enigmampc/enigma_km_sw:$TAG
-    privileged: true
     volumes:
       - name: sock
         path: /var/run/docker.sock
+    commands:
+      - cd discovery-docker-network/enigma-core
+      - echo $PASSWORD | docker login -u $USERNAME --password-stdin
+      - if [[ ${DRONE_BRANCH} == "master" ]]; then export DOCKER_TAG=latest; else export DOCKER_TAG=develop; fi
+      - docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_core_hw:$DOCKER_TAG --no-cache .
+      - docker push enigmampc/enigma_core_hw:$DOCKER_TAG
+      - docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=HW -t enigmampc/enigma_km_hw:$DOCKER_TAG --no-cache .
+      - docker push enigmampc/enigma_km_hw:$DOCKER_TAG
+      - docker build --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=SW -t enigmampc/enigma_core_sw:$DOCKER_TAG --no-cache .
+      - docker push enigmampc/enigma_core_sw:$DOCKER_TAG
+      - docker build -f Dockerfile.km --build-arg GIT_BRANCH_CORE=$DRONE_BRANCH --build-arg SGX_MODE=SW -t enigmampc/enigma_km_sw:$DOCKER_TAG --no-cache .
+      - docker push enigmampc/enigma_km_sw:$DOCKER_TAG
 
 volumes:
   - name: isgx


### PR DESCRIPTION
The CI now checks for matching branches across the other two repos, and conditionally builds against those other branches if a match is found. The logic is as follows:

1. If branch equals `master`, then use `latest` docker images
2. Else, if feature branch does NOT have a match in other repos, then use `develop` docker images
3. Else, if there is a match in only one other repo, then build a local image using that remote branch, AND reuse the existing `develop` for the repo there is no match (by tagging it as the one that will be used)
4. Else (there is a match on both repos), then build both local images.

Because of concurrency challenges derived from the fact that now three different repos `core`, `p2p` and `contract` handle the CI builds in the same host and they share docker resources, the images need to be separated between builds to avoid cross-contamination if there is a bogus image. Thus all images are tagged with `repo_build`, and deleted at the end of the build.

Analogous to:
- enigmampc/enigma-contract#159
- enigmampc/enigma-p2p#236