### PR TITLE
New block_number definition to distinguish between km & Ether block_number

### DIFF
--- a/enigma-principal/app/src/boot_network/keys_provider_http.rs
+++ b/enigma-principal/app/src/boot_network/keys_provider_http.rs
@@ -203,7 +203,7 @@ mod test {
     use web3::types::{H160, U256};
     use web3::types::Bytes;
 
-    use enigma_types::ContractAddress;
+    use enigma_types::{ContractAddress, Hash256};
     use epoch_u::epoch_types::ConfirmedEpochState;
     use esgx::epoch_keeper_u::set_or_verify_worker_params;
     use esgx::epoch_keeper_u::tests::get_worker_params;
@@ -223,8 +223,8 @@ mod test {
         let enclave = init_enclave_wrapper().unwrap();
         let workers: Vec<[u8; 20]> = vec![REF_WORKER];
         let stakes: Vec<u64> = vec![10000000000];
-        let block_number = 1;
-        let worker_params = get_worker_params(block_number, workers, stakes);
+        let km_block_number = 1;
+        let worker_params = get_worker_params(km_block_number, workers, stakes);
         let epoch_state = set_or_verify_worker_params(enclave.geteid(), &worker_params, None).unwrap();
         let rpc = {
             let mut io = IoHandler::new();
@@ -250,15 +250,16 @@ mod test {
     pub fn test_find_epoch_contract_addresses() {
         let msg = REF_MSG.from_hex().unwrap();
         let request = StateKeyRequest { data: StringWrapper(msg.to_hex()), sig: StringWrapper(REF_SIG.to_string()), block_number: None, addresses: None };
-        let address = ContractAddress::from(REF_CONTRACT_ADDR);
-        let mut selected_workers: HashMap<ContractAddress, H160> = HashMap::new();
+        let address = Hash256::from(REF_CONTRACT_ADDR);
+        let mut selected_workers: HashMap<Hash256, H160> = HashMap::new();
         selected_workers.insert(address, H160(REF_WORKER));
-        let block_number = U256::from(1);
-        let confirmed_state = Some(ConfirmedEpochState { selected_workers, block_number });
+        let ether_block_number = U256::from(3);
+        let confirmed_state = Some(ConfirmedEpochState { selected_workers, ether_block_number });
         let seed = U256::from(1);
         let sig = Bytes::from(REF_SIG.from_hex().unwrap());
         let nonce = U256::from(0);
-        let epoch_state = EpochState { seed, sig, nonce, confirmed_state };
+        let km_block_number = U256::from(1);
+        let epoch_state = EpochState { seed, sig, nonce, km_block_number, confirmed_state };
         let msg = PrincipalMessage::from_message(&request.get_data().unwrap()).unwrap();
         let results = PrincipalHttpServer::find_epoch_contract_addresses(&request, &msg, &epoch_state).unwrap();
         assert_eq!(results, vec![address])

--- a/enigma-principal/app/src/boot_network/principal_utils.rs
+++ b/enigma-principal/app/src/boot_network/principal_utils.rs
@@ -39,18 +39,18 @@ impl Principal for EnigmaContract {
             };
             let curr_block = block_number.low_u64() as usize;
             let prev_block = match epoch_provider.epoch_state_manager.last(true) {
-                Ok(state) => state.confirmed_state.unwrap().block_number,
+                Ok(state) => state.confirmed_state.unwrap().ether_block_number,
                 Err(_) => U256::from(0),
             };
             let prev_block_ref = prev_block.low_u64() as usize;
-            println!("[\u{1F50A} ] Blocks @ previous: {}, current: {}, next: {} [\u{1F50A} ]", prev_block_ref, curr_block, (prev_block_ref + epoch_size));
+            info!("[\u{1F50A} ] Blocks @ previous: {}, current: {}, next: {} [\u{1F50A} ]", prev_block_ref, curr_block, (prev_block_ref + epoch_size));
             if prev_block_ref == 0 || curr_block >= (prev_block_ref + epoch_size) {
                 println!("[\u{263C} ] New epoch found [\u{263C} ]");
                 epoch_provider
                     .set_worker_params(block_number, gas_limit, confirmations)
                     .expect("Unable to set worker params. Please recover manually.");
             } else {
-                println!("[\u{23f3} ] Epoch still active [\u{23f3} ]");
+                info!("[\u{23f3} ] Epoch still active [\u{23f3} ]");
             }
             thread::sleep(time::Duration::from_secs(polling_interval));
             if max_epochs != 0 {

--- a/enigma-principal/app/src/esgx/epoch_keeper_u.rs
+++ b/enigma-principal/app/src/esgx/epoch_keeper_u.rs
@@ -69,7 +69,7 @@ pub fn set_or_verify_worker_params(eid: sgx_enclave_id_t, worker_params: &InputW
             let seed = U256::from_big_endian(&rand_out);
             let sig = Bytes(sig_out.to_vec());
             let nonce = U256::from_big_endian(&nonce_out);
-            EpochState::new(seed, sig, nonce)
+            EpochState::new(seed, sig, nonce, worker_params.km_block_number)
         }
     };
     Ok(epoch_state_out)
@@ -84,9 +84,9 @@ pub mod tests {
 
     use super::*;
 
-    pub fn get_worker_params(block_number: u64, workers: Vec<[u8; 20]>, stakes: Vec<u64>) -> InputWorkerParams {
+    pub fn get_worker_params(km_block_number: u64, workers: Vec<[u8; 20]>, stakes: Vec<u64>) -> InputWorkerParams {
         InputWorkerParams {
-            block_number: U256::from(block_number),
+            km_block_number: U256::from(km_block_number),
             workers: workers.into_iter().map(|a| H160(a)).collect::<Vec<H160>>(),
             stakes: stakes.into_iter().map(|s| U256::from(s)).collect::<Vec<U256>>(),
         }
@@ -101,8 +101,8 @@ pub mod tests {
             [156, 26, 193, 252, 165, 167, 191, 244, 251, 126, 53, 154, 158, 14, 64, 194, 164, 48, 231, 179],
         ];
         let stakes: Vec<u64> = vec![90000000000];
-        let block_number = 1;
-        let worker_params = get_worker_params(block_number, workers, stakes);
+        let km_block_number = 1;
+        let worker_params = get_worker_params(km_block_number, workers, stakes);
         let epoch_state = set_or_verify_worker_params(enclave.geteid(), &worker_params, None).unwrap();
         assert!(epoch_state.confirmed_state.is_none());
         enclave.destroy();
@@ -115,8 +115,8 @@ pub mod tests {
             [156, 26, 193, 252, 165, 167, 191, 244, 251, 126, 53, 154, 158, 14, 64, 194, 164, 48, 231, 179],
         ];
         let stakes: Vec<u64> = vec![90000000000];
-        let block_number = 1;
-        let worker_params = get_worker_params(block_number, workers, stakes);
+        let km_block_number = 1;
+        let worker_params = get_worker_params(km_block_number, workers, stakes);
         for i in 0..5 {
             let epoch_state = set_or_verify_worker_params(enclave.geteid(), &worker_params, None).unwrap();
             assert!(epoch_state.confirmed_state.is_none());

--- a/enigma-principal/app/src/esgx/keys_keeper_u.rs
+++ b/enigma-principal/app/src/esgx/keys_keeper_u.rs
@@ -94,19 +94,17 @@ pub mod tests {
         // Since the seed is not predictable in advance, test with a single worker to predict the selected worker
         let workers: Vec<[u8; 20]> = vec![[161, 186, 144, 238, 40, 242, 102, 161, 178, 93, 177, 83, 107, 128, 189, 132, 112, 8, 163, 252]];
         let stakes: Vec<u64> = vec![10000000000];
-        let block_number = 1;
-        let worker_params = get_worker_params(block_number, workers, stakes);
+        let km_block_number = 1;
+        let worker_params = get_worker_params(km_block_number, workers, stakes);
         let epoch_state = set_or_verify_worker_params(enclave.geteid(), &worker_params, None).unwrap();
 
         // From the km_primitives uint tests
         let msg = StringWrapper("83a464617461a752657175657374a269649cccd763674174cc9b3f300dccd2ccb0cc8ba67075626b6579dc0040ccc90b2205ccf9cc9358661320ccffccb763ccb57614ccf8ccaa1fccb86d6a087869ccd81acce5ccf16fcc9206cc98344136cca4ccefccb105ccbbccca1c5057ccba25067eccc101cc82ccee21445cccf91e79ccb176447239".to_string());
         let sig = StringWrapper("2535cfe1bcea215dc552acbca1a213354e055709f8e071c593bb9a8c1551b7791d6fd611ded1912065b3b518f6a75a1c78643b0a2e06397707b21768be637cb41b".to_string());
-        println!("The mock message: {:?}", msg);
-        println!("The mock sig: {:?}", sig);
 
         let request = StateKeyRequest { data: msg, sig, block_number: None, addresses: None };
         let response = get_enc_state_keys(enclave.geteid(), request, epoch_state.nonce, &[]).unwrap();
-        println!("Got response: {:?}", response);
+
         enclave.destroy();
     }
 }

--- a/enigma-principal/enclave/src/epoch_keeper_t/mod.rs
+++ b/enigma-principal/enclave/src/epoch_keeper_t/mod.rs
@@ -199,7 +199,7 @@ pub mod tests {
     // noinspection RsTypeCheck
     pub fn test_get_epoch_worker_internal() {
         let worker_params = InputWorkerParams {
-            block_number: U256::from(1),
+            km_block_number: U256::from(1),
             workers: vec![H160::from([0u8;20]), H160::from([1u8;20]), H160::from([2u8;20]), H160::from([3u8;20])],
             stakes: vec![U256::from(1), U256::from(1), U256::from(1), U256::from(1)],
         };
@@ -211,7 +211,7 @@ pub mod tests {
     pub fn test_create_epoch_image() {
         let expected_image1: Vec<u8> = vec![0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 98, 42, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0];
         let worker_params1 = InputWorkerParams {
-            block_number: U256::from(1),
+            km_block_number: U256::from(1),
             workers: vec![],
             stakes: vec![],
         };
@@ -238,7 +238,7 @@ pub mod tests {
             4000000000,
         ];
         let worker_params2 = InputWorkerParams {
-            block_number: U256::from(1),
+            km_block_number: U256::from(1),
             workers: workers.into_iter().map(|a| H160(a)).collect(),
             stakes: stakes.into_iter().map(|s| U256::from(s.clone())).collect(),
         };

--- a/enigma-tools-m/src/keeper_types.rs
+++ b/enigma-tools-m/src/keeper_types.rs
@@ -46,7 +46,7 @@ impl RawEncodable for WorkerSelectionToken {
 
 #[derive(Debug, Clone)]
 pub struct InputWorkerParams {
-    pub block_number: U256,
+    pub km_block_number: U256,
     pub workers: Vec<Address>,
     pub stakes: Vec<U256>,
 }
@@ -115,7 +115,7 @@ impl InputWorkerParams {
 impl Decodable for InputWorkerParams {
     fn decode(rlp: &UntrustedRlp) -> Result<Self, DecoderError> {
         Ok(Self {
-            block_number: U256::from_bigint(rlp.val_at(0)?),
+            km_block_number: U256::from_bigint(rlp.val_at(0)?),
             workers: rlp.list_at(1)?.iter().map(|a| H160::from_bigint(*a)).collect::<Vec<_>>(),
             stakes: rlp.list_at(2)?.iter().map(|b| U256::from_bigint(*b)).collect::<Vec<_>>(),
         })
@@ -125,7 +125,7 @@ impl Decodable for InputWorkerParams {
 impl Encodable for InputWorkerParams {
     fn rlp_append(&self, s: &mut RlpStream) {
         s.begin_list(3);
-        s.append(&bigint::U256(self.block_number.0));
+        s.append(&bigint::U256(self.km_block_number.0));
         s.append_list(&self.workers.iter().map(|a| bigint::H160(a.0)).collect::<Vec<_>>());
         s.append_list(&self.stakes.iter().map(|b| bigint::U256(b.0)).collect::<Vec<_>>());
     }


### PR DESCRIPTION
This PR fixes a bug that was found when running a network with many nodes which increases the latency and which simulates a realistic network.

The KM defines the new epoch on a block and uses it to get the list of the workers which will be participating in the following epoch.
Then it sends the Event to the Enigma Contract (**which might take time to get it**) and it signs a transaction which defines the **real** start of the epoch and might be in a different block_number.

Till now, we stored in the enclave of the km the km_block_number and in the untrusted we stored the ether_block_number and when they needed to be verified one against the other bad things happened.

So we split it into two numbers in the untrusted side, and when needed to know the real epoch the ether_block_number is given and when needed to verify the workers participating in the epoch the km_block_number is given.