### PR TITLE
Improvement of KM logs

### DIFF
--- a/enigma-principal/app/src/boot_network/keys_provider_http.rs
+++ b/enigma-principal/app/src/boot_network/keys_provider_http.rs
@@ -135,7 +135,7 @@ impl PrincipalHttpServer {
 
     fn handle_error(internal_err: Error) -> ServerError {
         if let Some(err) = internal_err.downcast_ref::<EnclaveFailError>() {
-            println!("Got internal error: {:?}", internal_err.as_fail());
+            error!("{:?}", internal_err.as_fail());
             let server_err = match &err.err {
                 EnclaveReturn::WorkerAuthError => {
                     ServerError {

--- a/enigma-principal/app/src/boot_network/keys_provider_http.rs
+++ b/enigma-principal/app/src/boot_network/keys_provider_http.rs
@@ -106,14 +106,13 @@ impl PrincipalHttpServer {
         let image = msg.to_sign()?;
         let sig = request.get_sig()?;
         let worker = KeyPair::recover(&image, sig)?.address();
-        println!("Searching contract addresses for recovered worker: {:?}", worker.to_vec());
+        trace!("Searching contract addresses for recovered worker: {:?}", worker.to_vec());
         let addrs = epoch_state.get_contract_addresses(&worker.into())?;
         Ok(addrs)
     }
 
     #[logfn(DEBUG)]
     pub fn get_state_keys(epoch_provider: &EpochProvider, request: StateKeyRequest) -> Result<Value, Error> {
-        println!("Got get_state_keys request: {:?}", request);
         let epoch_state = match request.block_number.clone() {
             Some(block_number) => epoch_provider.find_epoch(block_number.try_into()?)?,
             None => epoch_provider.find_last_epoch()?,
@@ -121,12 +120,10 @@ impl PrincipalHttpServer {
         let addresses = &request.addresses;
         let addrs: Vec<ContractAddress> = {
             if let Some(addrs) = addresses {
-                println!("Found addresses in message: {:?}", addrs);
                 let res: Result<Vec<ContractAddress>, _>  = addrs.iter().map(|item| ContractAddress::from_hex(item)).collect();
                 res?
             }
             else{
-                println!("No addresses in message, reading from epoch state...");
                 let msg = PrincipalMessage::from_message(&request.get_data()?)?;
                 Self::find_epoch_contract_addresses(&request, &msg, &epoch_state)?
             }
@@ -137,8 +134,8 @@ impl PrincipalHttpServer {
     }
 
     fn handle_error(internal_err: Error) -> ServerError {
-        println!("Got internal error: {:?}", internal_err.as_fail());
         if let Some(err) = internal_err.downcast_ref::<EnclaveFailError>() {
+            println!("Got internal error: {:?}", internal_err.as_fail());
             let server_err = match &err.err {
                 EnclaveReturn::WorkerAuthError => {
                     ServerError {
@@ -209,7 +206,7 @@ impl PrincipalHttpServer {
         });
         let server =
             ServerBuilder::new(io).start_http(&format!("0.0.0.0:{}", port).parse().unwrap()).expect("Unable to start RPC server");
-        println!("JSON-RPC HTTP server listening on port: {}", port);
+        info!("JSON-RPC listening on port: {}", port);
         server.wait();
     }
 }

--- a/enigma-principal/app/src/boot_network/principal_utils.rs
+++ b/enigma-principal/app/src/boot_network/principal_utils.rs
@@ -51,7 +51,7 @@ impl Principal for EnigmaContract {
             let prev_block_ref = prev_block.low_u64() as usize;
             trace!("Blocks @ previous: {}, current: {}, next: {}", prev_block_ref, curr_block, (prev_block_ref + epoch_size));
             if prev_block_ref == 0 || curr_block >= (prev_block_ref + epoch_size) {
-                info!("New epoch for block number {} [epoch size {}]", curr_block, epoch_size);
+                trace!("New epoch for block number {} [epoch size {}]", curr_block, epoch_size);
                 epoch_provider
                     .set_worker_params(block_number, gas_limit, confirmations)
                     .expect("Unable to set worker params. Please recover manually.");

--- a/enigma-principal/app/src/epoch_u/epoch_provider.rs
+++ b/enigma-principal/app/src/epoch_u/epoch_provider.rs
@@ -15,7 +15,7 @@ use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 use sgx_types::sgx_enclave_id_t;
 use web3::types::{H256, TransactionReceipt, U256};
-use rustc_hex::{ToHex};
+use rustc_hex::ToHex;
 
 use common_u::errors::{EpochStateIOErr, EpochStateTransitionErr, EpochStateUndefinedErr};
 use enigma_tools_u::web3_utils::enigma_contract::{ContractFuncs, ContractQueries, EnigmaContract};

--- a/enigma-principal/app/src/epoch_u/epoch_provider.rs
+++ b/enigma-principal/app/src/epoch_u/epoch_provider.rs
@@ -158,7 +158,7 @@ impl EpochStateManager {
         let epoch_state_list = guard.deref().clone();
         drop(guard);
         if epoch_state_list.is_empty() {
-            return Ok(fs::remove_file(&self.state_path).unwrap_or_else(|_| println!("No epoch state file to remove")));
+            return Ok(fs::remove_file(&self.state_path).unwrap_or_else(|_| trace!("No epoch state file to remove")));
         }
         let mut file = File::create(&self.state_path).
             map_err(|e| EpochStateIOErr { message: format!("Unable to write the EpochState list: {}", e)})?;
@@ -356,7 +356,7 @@ impl EpochProvider {
     pub fn confirm_epoch(&self, epoch_state: &mut EpochState, ether_block_number: U256, worker_params: InputWorkerParams) -> Result<(), Error> {
         let sc_addresses = self.contract.get_all_secret_contract_addresses()?;
 
-        trace!("The secret contract addresses: {:?}",
+        debug!("The secret contract addresses: {:?}",
                sc_addresses.iter().map(|item| {item.to_hex()}).collect::<Vec<String>>());
         epoch_state.confirm(ether_block_number, &worker_params, sc_addresses)?;
         Ok(())

--- a/enigma-principal/app/src/epoch_u/epoch_types.rs
+++ b/enigma-principal/app/src/epoch_u/epoch_types.rs
@@ -50,7 +50,7 @@ impl EpochState {
     pub fn confirm(
         &mut self, ether_block_number: U256, worker_params: &InputWorkerParams, sc_addresses: Vec<ContractAddress>,
     ) -> Result<(), Error> {
-        println!("Confirmed epoch with worker params: {:?}", worker_params);
+        info!("Confirmed epoch with worker params: {:?}", worker_params);
         let mut selected_workers: HashMap<ContractAddress, Address> = HashMap::new();
         for sc_address in sc_addresses {
             match worker_params.get_selected_worker(sc_address, self.seed) {

--- a/enigma-principal/app/src/epoch_u/epoch_types.rs
+++ b/enigma-principal/app/src/epoch_u/epoch_types.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use rustc_hex::ToHex;
 
 use enigma_tools_m::keeper_types::InputWorkerParams;
 use ethabi::{Event, EventParam, ParamType};
@@ -52,17 +53,16 @@ impl EpochState {
         println!("Confirmed epoch with worker params: {:?}", worker_params);
         let mut selected_workers: HashMap<ContractAddress, Address> = HashMap::new();
         for sc_address in sc_addresses {
-            println!("Getting the selected worker for: {:?}", sc_address);
             match worker_params.get_selected_worker(sc_address, self.seed) {
                 Some(worker) => {
-                    println!("Found selected worker: {:?} for contract: {:?}", worker, sc_address);
+                    trace!("Found selected worker: {:?} for contract: {:?}", worker, sc_address.to_hex());
                     match selected_workers.insert(sc_address, worker) {
-                        Some(prev) => println!("Selected worker inserted after: {:?}", prev),
-                        None => println!("First selected worker inserted"),
+                        Some(prev) => trace!("Selected worker inserted after: {:?}", prev),
+                        None => trace!("First selected worker inserted"),
                     }
                 }
                 None => {
-                    println!("Selected worker not found for contract: {:?}", sc_address);
+                    trace!("Selected worker not found for contract: {:?}", sc_address.to_hex());
                 }
             }
         }

--- a/enigma-principal/app/src/esgx/epoch_keeper_u.rs
+++ b/enigma-principal/app/src/esgx/epoch_keeper_u.rs
@@ -35,12 +35,11 @@ extern "C" {
 #[logfn(DEBUG)]
 pub fn set_or_verify_worker_params(eid: sgx_enclave_id_t, worker_params: &InputWorkerParams, epoch_state: Option<EpochState>) -> Result<EpochState, Error> {
     let mut retval: EnclaveReturn = EnclaveReturn::Success;
-    println!("Evaluating nonce/seed based on EpochState: {:?}", epoch_state);
     let (nonce_in, seed_in) = match epoch_state.clone() {
         Some(e) => (e.nonce.into(), e.seed.into()),
         None => ([0; 32], [0; 32])
     };
-    println!("Calling enclave set_worker_params with nonce/seed: {:?}/{:?}", nonce_in.to_vec().to_hex(), seed_in.to_vec().to_hex());
+    debug!("Calling enclave set_worker_params with nonce/seed: {:?}/{:?}", nonce_in.to_vec().to_hex(), seed_in.to_vec().to_hex());
     let (mut nonce_out, mut rand_out) = ([0; 32], [0; 32]);
     let mut sig_out: [u8; 65] = [0; 65];
     // Serialize the InputWorkerParams into RLP

--- a/enigma-principal/enclave/src/epoch_keeper_t/mod.rs
+++ b/enigma-principal/enclave/src/epoch_keeper_t/mod.rs
@@ -148,17 +148,15 @@ pub(crate) fn ecall_set_worker_params_internal(worker_params_rlp: &[u8], seed_in
                 Some(nonce) => nonce + 1,
                 None => INIT_NONCE.into(),
             };
-            debug_println!("Creating new epoch with nonce {:?}", nonce);
             *nonce_out = EpochNonce::from(nonce);
             rsgx_read_rand(&mut rand_out[..])?;
             let seed = U256::from(rand_out.as_ref());
             let epoch = Epoch { nonce, seed, worker_params };
-            debug_println!("Generated random seed: {:?}", seed);
+            debug_println!("Creating new epoch with nonce {:?} and seed: {:?}", nonce, seed);
             store_epoch(epoch.clone())?;
             epoch
         }
     };
-    debug_println!("Inserting epoch: {:?} in cache", epoch);
     // Removing the first item (lower nonce) from the cache if capacity is reached
     if guard.len() == EPOCH_CAP {
         // Safe to unwrap because we just verified the size of the `HashMap`

--- a/enigma-principal/enclave/src/keys_keeper_t/mod.rs
+++ b/enigma-principal/enclave/src/keys_keeper_t/mod.rs
@@ -50,7 +50,8 @@ fn get_state_keys(keys_map: &mut HashMap<ContractAddress, StateKey>,
         let key = match keys_map.get(&addr) {
             Some(&key) => Some(key),
             None => {
-                debug_println!("State key for contract {:?} not found in cache, fetching sealed document.", addr.to_hex());
+              //  let p = addr.to_vec().to_hex();
+                debug_println!("State key for contract {:?} not found in cache, fetching sealed document.", addr.to_vec().to_hex::<String>());
                 let path = get_document_path(&addr);
                 if is_document(&path) {
                     let mut sealed_log_out = [0u8; SEAL_LOG_SIZE];
@@ -58,12 +59,12 @@ fn get_state_keys(keys_map: &mut HashMap<ContractAddress, StateKey>,
                     let doc = SealedDocumentStorage::<StateKey>::unseal(&mut sealed_log_out)?;
                     match doc {
                         Some(doc) => {
-                            debug_println!("State key for contract {:?} is unsealed", addr.to_hex());
+                            debug_println!("State key for contract {:?} is unsealed", addr.to_hex::<String>());
                             keys_map.insert(addr, doc.data);
                             Some(doc.data)
                         }
                         None => {
-                            debug_println!("Contract {:?} is new, state key does not exist", addr);
+                            debug_println!("Contract {:?} is new, state key does not exist", addr.to_hex::<String>());
                             None
                         }
                     }
@@ -96,7 +97,7 @@ fn new_state_keys(keys_map: &mut HashMap<ContractAddress, StateKey>,
         save_sealed_document(&path, &sealed_log_in)?;
         // Add to cache
         keys_map.insert(addr, doc.data);
-        debug_println!("New key for contract {:?} is stored successfully", addr.to_hex());
+        debug_println!("New key for contract {:?} is stored successfully", addr.to_hex::<String>());
 
         results.push(doc.data);
     }
@@ -165,7 +166,7 @@ pub(crate) fn ecall_get_enc_state_keys_internal(
     // Signing the encrypted response
     // This is important because the response might be delivered by an intermediary
     *sig_out = SIGNING_KEY.sign(&response)?;
-    debug_println!("Get state key response requested for secret contract {:?}: {:?}", recovered_addr.to_hex(), response.to_hex::<String>());
+    debug_println!("Get state key response requested for secret contract {:?}: {:?}", recovered_addr.to_hex::<String>(), response.to_hex::<String>());
     Ok(response)
 }
 

--- a/enigma-principal/enclave/src/keys_keeper_t/mod.rs
+++ b/enigma-principal/enclave/src/keys_keeper_t/mod.rs
@@ -164,7 +164,7 @@ pub(crate) fn ecall_get_enc_state_keys_internal(
     let response_msg = PrincipalMessage::new_id(response_msg_data, msg_id, pubkey);
     // Generate the iv from the first 12 bytes of a new random number
     let response = response_msg.encrypt(&derived_key)?.into_message()?;
-    println!("The partially encrypted response: {:?}", response.to_hex::<String>());
+    debug_println!("The partially encrypted response: {:?}", response.to_hex::<String>());
     // Signing the encrypted response
     // This is important because the response might be delivered by an intermediary
     *sig_out = SIGNING_KEY.sign(&response)?;

--- a/enigma-principal/enclave/src/keys_keeper_t/mod.rs
+++ b/enigma-principal/enclave/src/keys_keeper_t/mod.rs
@@ -50,20 +50,20 @@ fn get_state_keys(keys_map: &mut HashMap<ContractAddress, StateKey>,
         let key = match keys_map.get(&addr) {
             Some(&key) => Some(key),
             None => {
-                println!("State key not found in cache, fetching sealed document.");
+                debug_println!("State key for contract {:?} not found in cache, fetching sealed document.", addr.to_hex());
                 let path = get_document_path(&addr);
                 if is_document(&path) {
-                    debug_println!("Unsealing state key.");
                     let mut sealed_log_out = [0u8; SEAL_LOG_SIZE];
                     load_sealed_document(&path, &mut sealed_log_out)?;
                     let doc = SealedDocumentStorage::<StateKey>::unseal(&mut sealed_log_out)?;
                     match doc {
                         Some(doc) => {
+                            debug_println!("State key for contract {:?} is unsealed", addr.to_hex());
                             keys_map.insert(addr, doc.data);
                             Some(doc.data)
                         }
                         None => {
-                            debug_println!("State key {:?} does not exist", addr);
+                            debug_println!("Contract {:?} is new, state key does not exist", addr);
                             None
                         }
                     }
@@ -95,10 +95,9 @@ fn new_state_keys(keys_map: &mut HashMap<ContractAddress, StateKey>,
         let path = get_document_path(&addr);
         save_sealed_document(&path, &sealed_log_in)?;
         // Add to cache
-        match keys_map.insert(addr, doc.data) {
-            Some(prev) => println!("New key stored successfully"),
-            None => println!("Initial key stored successfully"),
-        }
+        keys_map.insert(addr, doc.data);
+        debug_println!("New key for contract {:?} is stored successfully", addr.to_hex());
+
         results.push(doc.data);
     }
     Ok(results)
@@ -140,7 +139,6 @@ pub(crate) fn ecall_get_enc_state_keys_internal(
     let msg_id = msg.get_id();
     // Create the request image before the worker selection guard to avoid cloning the message data
     let image = msg.to_sign()?;
-    debug_println!("Generated hash image: {:?} for request: {:?}", image, msg);
     let recovered_addr = KeyPair::recover(&image, sig)?.address();
     let nonce = U256::from(epoch_nonce.as_ref());
     for sc_addr in sc_addrs.clone() {
@@ -164,10 +162,10 @@ pub(crate) fn ecall_get_enc_state_keys_internal(
     let response_msg = PrincipalMessage::new_id(response_msg_data, msg_id, pubkey);
     // Generate the iv from the first 12 bytes of a new random number
     let response = response_msg.encrypt(&derived_key)?.into_message()?;
-    debug_println!("The partially encrypted response: {:?}", response.to_hex::<String>());
     // Signing the encrypted response
     // This is important because the response might be delivered by an intermediary
     *sig_out = SIGNING_KEY.sign(&response)?;
+    debug_println!("Get state key response requested for secret contract {:?}: {:?}", recovered_addr.to_hex(), response.to_hex::<String>());
     Ok(response)
 }
 

--- a/enigma-principal/enclave/src/lib.rs
+++ b/enigma-principal/enclave/src/lib.rs
@@ -114,7 +114,7 @@ pub unsafe extern "C" fn ecall_get_enc_state_keys(msg: *const u8, msg_len: usize
     let response = match ecall_get_enc_state_keys_internal(msg_bytes, addrs_bytes, *sig, *epoch_nonce, sig_out) {
         Ok(response) => response,
         Err(err) => {
-            println!("get_enc_state_keys error: {:?}", err);
+            debug_println!("get_enc_state_keys error: {:?}", err);
             return err.into();
         }
     };

--- a/enigma-principal/enclave/src/lib.rs
+++ b/enigma-principal/enclave/src/lib.rs
@@ -99,10 +99,9 @@ pub unsafe extern "C" fn ecall_set_worker_params(worker_params_rlp: *const u8, w
     let worker_params_rlp = slice::from_raw_parts(worker_params_rlp, worker_params_rlp_len);
 
     match ecall_set_worker_params_internal(worker_params_rlp, seed_in, nonce_in, rand_out, nonce_out, sig_out) {
-        Ok(_) => println!("Worker parameters set successfully"),
-        Err(err) => return err.into(),
-    };
-    EnclaveReturn::Success
+        Ok(_) => EnclaveReturn::Success,
+        Err(err) => err.into(),
+    }
 }
 
 #[no_mangle]

--- a/enigma-tools-t/src/document_storage_t.rs
+++ b/enigma-tools-t/src/document_storage_t.rs
@@ -92,7 +92,7 @@ pub fn save_sealed_document(path: &PathBuf, sealed_document: &[u8]) -> Result<()
         }
     };
     match file.write_all(&sealed_document) {
-        Ok(_) => println!("Sealed document: {:?} written successfully.", path),
+        Ok(_) => debug_println!("Sealed document: {:?} written successfully.", path),
         Err(err) => {
             return Err(SystemError(OcallError { command: "sealed_document".to_string(), err: format!("{:?}", err) }));
         }

--- a/enigma-tools-u/src/web3_utils/enigma_contract.rs
+++ b/enigma-tools-u/src/web3_utils/enigma_contract.rs
@@ -158,7 +158,7 @@ impl ContractQueries for EnigmaContract {
         Ok(signing_address)
     }
 
-    #[logfn(INFO)]
+    #[logfn(DEBUG)]
     fn get_active_workers(&self, block_number: U256) -> Result<(Vec<H160>, Vec<U256>), Error> {
         let worker_params: (Vec<Address>, Vec<U256>) =
             match self.w3_contract.query("getActiveWorkers", block_number, self.account, Options::default(), None).wait() {


### PR DESCRIPTION
This PR contains the following changed in KM logs:
- moving all prints in trusted to `debug_println!`
- removing some redundant messages
- making some messages more informative
- moving error prints to `error!`
- removing logs for epoch transaction error, which appears each epoch and is part of a normal process
- reorganization of messages by levels:
    - `debug!` contains control flow of setting worker parameters and KM registration
    - `trace!` contains epoch confirmation, watch blocks, and epoch state list information

