### PR TITLE
added clarity to DB logs

### DIFF
--- a/enigma-core/app/src/common_u/errors.rs
+++ b/enigma-core/app/src/common_u/errors.rs
@@ -59,18 +59,20 @@ pub enum DBErrKind {
     KeyExists,
     CreateError,
     FetchError,
-    MissingKey,
+    MissingKey(String),
     UpdateError,
+    MissingKeys,
 }
 
 impl fmt::Display for DBErrKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let printable = match *self {
-            DBErrKind::KeyExists => "The Key already exists",
-            DBErrKind::CreateError => "Failed to create the key",
-            DBErrKind::FetchError => "Failed to fetch the data",
-            DBErrKind::MissingKey => "The Key doesn't exist",
-            DBErrKind::UpdateError => "Failed to update the key",
+        let printable: String = match &*self {
+            DBErrKind::KeyExists => "The Key already exists".into(),
+            DBErrKind::CreateError => "Failed to create the key".into(),
+            DBErrKind::FetchError => "Failed to fetch the data".into(),
+            DBErrKind::MissingKey(k) => format!("The following Key doesn't exist: {}", &k),
+            DBErrKind::UpdateError => "Failed to update the key".into(),
+            DBErrKind::MissingKeys => "Keys don't exist the DB".into(),
         };
         write!(f, "{}", printable)
     }

--- a/enigma-core/app/src/db/dal.rs
+++ b/enigma-core/app/src/db/dal.rs
@@ -216,8 +216,8 @@ impl<'a, K: SplitKey> CRUDInterface<Error, &'a K, Vec<u8>, &'a [u8]> for DB {
     fn read(&self, key: &'a K) -> Result<Vec<u8>, Error> {
         key.as_split(|hash, index_key| {
             trace!("DB: Read: contract_address: {}, key: {:?}", hash, index_key);
-            let cf_key = self.database.cf_handle(&hash).ok_or(DBErr { command: "read".to_string(), kind: DBErrKind::MissingKey })?;
-            let value = self.database.get_cf(cf_key, &index_key)?.ok_or(DBErr { command: "read".to_string(), kind: DBErrKind::MissingKey })?;
+            let cf_key = self.database.cf_handle(&hash).ok_or(DBErr { command: "read".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) })?;
+            let value = self.database.get_cf(cf_key, &index_key)?.ok_or(DBErr { command: "read".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) })?;
             Ok(value.to_vec())
         })
     }
@@ -226,10 +226,10 @@ impl<'a, K: SplitKey> CRUDInterface<Error, &'a K, Vec<u8>, &'a [u8]> for DB {
     fn update(&mut self, key: &'a K, value: &'a [u8]) -> Result<(), Error> {
         key.as_split(|hash, index_key| {
             trace!("Updating DB: contract_address: {}, key: {:?}, value: {:?}", hash, index_key, value);
-            let cf_key = self.database.cf_handle(&hash).ok_or(DBErr { command: "update".to_string(), kind: DBErrKind::MissingKey })?;
+            let cf_key = self.database.cf_handle(&hash).ok_or(DBErr { command: "update".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) })?;
 
             if self.database.get_cf(cf_key, &index_key)?.is_none() {
-                return Err(DBErr { command: "update".to_string(), kind: DBErrKind::MissingKey }.into());
+                return Err(DBErr { command: "update".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) }.into());
             }
 
             let mut write_options = WriteOptions::default();
@@ -243,10 +243,10 @@ impl<'a, K: SplitKey> CRUDInterface<Error, &'a K, Vec<u8>, &'a [u8]> for DB {
     fn delete(&mut self, key: &'a K) -> Result<(), Error> {
         key.as_split(|hash, index_key| {
             trace!("DB: Delete: contract_address: {}, key: {:?}", hash, index_key);
-            let cf_key = self.database.cf_handle(&hash).ok_or(DBErr { command: "delete".to_string(), kind: DBErrKind::MissingKey })?;
+            let cf_key = self.database.cf_handle(&hash).ok_or(DBErr { command: "delete".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) })?;
 
             if self.database.get_cf(cf_key, &index_key)?.is_none() {
-                return Err(DBErr { command: "delete".to_string(), kind: DBErrKind::MissingKey }.into());
+                return Err(DBErr { command: "delete".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) }.into());
             }
             self.database.delete_cf(cf_key, &index_key)?;
             Ok(())
@@ -258,7 +258,7 @@ impl<'a, K: SplitKey> CRUDInterface<Error, &'a K, Vec<u8>, &'a [u8]> for DB {
         key.as_split(|hash, _| {
             trace!("DB: Delete Contract: contract_address: {}", hash);
             self.database.drop_cf(&hash).
-                map_err(|_| DBErr { command: "delete_contract".to_string(), kind: DBErrKind::MissingKey }.into())
+                map_err(|_| DBErr { command: "delete_contract".to_string(), kind: DBErrKind::MissingKey(hash.to_string()) }.into())
         })
     }
 

--- a/enigma-core/app/src/db/iterator.rs
+++ b/enigma-core/app/src/db/iterator.rs
@@ -266,10 +266,10 @@ impl P2PCalls for DB {
         let str_addr = address.to_hex();
         trace!("DB: Get Tip: cf: {}, ", str_addr);
         let cf_key =
-            self.database.cf_handle(&str_addr).ok_or(DBErr { command: "get_tip".to_string(), kind: DBErrKind::MissingKey })?;
+            self.database.cf_handle(&str_addr).ok_or(DBErr { command: "get_tip".to_string(), kind: DBErrKind::MissingKey(str_addr.clone()) })?;
 
         let iter = self.database.prefix_iterator_cf(cf_key, DELTA_PREFIX)?;
-        let last = iter.last().ok_or(DBErr { command: "get_tip".to_string(), kind: DBErrKind::MissingKey })?;
+        let last = iter.last().ok_or(DBErr { command: "get_tip".to_string(), kind: DBErrKind::MissingKey(str_addr.clone()) })?;
         let k_key = K::from_split(&str_addr, &*last.0)?;
         let value =  (&*last.1).to_vec();
         trace!("DB: Continue Get Tip, key: {:?} value: {:?}", k_key, value);
@@ -298,7 +298,7 @@ impl P2PCalls for DB {
             // list_cf returns "Default" as the first CF,
             // so we remove it if we have elements other than that in the DB.
             l if l > 1 => cf_list.remove(0),
-            _ => return Err(DBErr { command: "get_all_addresses".to_string(), kind: DBErrKind::MissingKey }.into()),
+            _ => return Err(DBErr { command: "get_all_addresses".to_string(), kind: DBErrKind::MissingKeys }.into()),
         };
         // convert all addresses from strings to slices.
         // filter_map filters all None types from the iterator,
@@ -323,14 +323,16 @@ impl P2PCalls for DB {
 
     #[logfn(TRACE)]
     fn get_delta<K: SplitKey>(&self, key: K) -> ResultVec<u8> {
-
-        Ok(self.read(&key)?)
+        Ok(self.read(&key).map_err(|_|
+            key.as_split(| addr, _ | {
+                DBErr { command: "get_delta".to_string(), kind: DBErrKind::MissingKey(addr.to_string()) }
+            }))?)
     }
 
     #[logfn(TRACE)]
     fn get_contract(&self, contract_address: ContractAddress) -> ResultVec<u8> {
         let key = DeltaKey { contract_address, key_type: Stype::ByteCode };
-        Ok(self.read(&key)?)
+        Ok(self.read(&key).map_err(|_| DBErr { command: "get_contract".to_string(), kind: DBErrKind::MissingKey(contract_address.to_hex()) })?)
     }
 
     #[logfn(TRACE)]
@@ -348,7 +350,7 @@ impl P2PCalls for DB {
         from.as_split(|from_hash, from_key| {
             // make sure the address exists as a CF in the DB
             let cf_key =
-                self.database.cf_handle(&from_hash).ok_or(DBErr { command: "read".to_string(), kind: DBErrKind::MissingKey })?;
+                self.database.cf_handle(&from_hash).ok_or(DBErr { command: "read".to_string(), kind: DBErrKind::MissingKey(from_hash.to_string()) })?;
 
             // if exists, extract the second key for the range.
             to.as_split(|hash_to, to_key| {

--- a/enigma-core/app/tests/ipc_identity_and_general_tests.rs
+++ b/enigma-core/app/tests/ipc_identity_and_general_tests.rs
@@ -53,7 +53,7 @@ fn test_compute_on_empty_address() {
     let callable  = "mint(bytes32,uint256)";
     let (_val,_) = contract_compute(port, _address.into(), &args, callable);
     let accepted_err =  _val["msg"].as_str().unwrap();
-    assert_eq!(accepted_err, "Error while trying to read, Because: The Key doesn\'t exist");
+    assert_eq!(accepted_err.to_string(), format!("Error while trying to get_contract, Because: The following Key doesn\'t exist: {}", _address.to_hex()));
 }
 
 #[test]


### PR DESCRIPTION
added clarity to the error logs coming from the DB. get_deltas and get_contract would get until now a "read" error so I modified it to the function which made the call and in addition, I added the contract address of which we are querying.