### PR TITLE
Improvement enclave init process + core logs

### DIFF
--- a/enigma-core/app/src/esgx/general.rs
+++ b/enigma-core/app/src/esgx/general.rs
@@ -1,8 +1,7 @@
-use dirs;
 use enigma_tools_u::{self, esgx::general::storage_dir};
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
-use std::{fs, path, io::Write};
+use std::{fs, path};
 use log;
 
 static ENCLAVE_FILE: &'static str = "../bin/enclave.signed.so";
@@ -11,52 +10,11 @@ pub static ENCLAVE_DIR: &'static str = ".enigma";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Step 1: try to retrieve the launch token saved by last transaction
-    //         if there is no token, then create a new one.
-    //
-    // try to get the token saved in $HOME */
-    //let mut home_dir = path::PathBuf::new();
-
-    let use_token = match dirs::home_dir() {
-        Some(path) => {
-            info!("Home dir is {}", path.display());
-            //home_dir = path;
-            true
-        }
-        None => {
-            error!("Cannot get home dir");
-            false
-        }
-    };
-
-    // Step : try to create a .enigma folder for storing all the files
-    // Create a directory, returns `io::Result<()>`
-    //let storage_path = home_dir.join(ENCLAVE_DIR);
+    // Create a storage folder for storage (Sealed, token, etc)
+    // If a storage folder is inaccessible, enclave cannot seal info
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
-    match fs::create_dir(&storage_path) {
-        Err(why) => {
-            error!("Create .enigma folder => {:?}", why.kind());
-        }
-        Ok(_) => {
-            info!("Created new .enigma folder => {:?}", storage_path);
-        }
-    };
-    // Create the home/dir/.enigma folder for storage (Sealed, token , etc )
+    fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);
 
-    let (enclave, launch_token) = enigma_tools_u::esgx::init_enclave(&token_file, use_token, &ENCLAVE_FILE)?;
-    // Step 3: save the launch token if it is updated
-    if use_token && launch_token.is_some() {
-        // reopen the file with write capability
-        match fs::File::create(&token_file) {
-            Ok(mut f) => match f.write_all(&launch_token.unwrap()) {
-                Ok(_) => info!("Saved updated launch token!"),
-                Err(_) => error!("Failed to save updated launch token!"),
-            },
-            Err(_) => {
-                error!("Failed to save updated enclave token, but doesn't matter");
-            }
-        }
-    }
-    Ok(enclave)
+    enigma_tools_u::esgx::init_enclave(&token_file, &ENCLAVE_FILE)
 }

--- a/enigma-core/app/src/esgx/general.rs
+++ b/enigma-core/app/src/esgx/general.rs
@@ -11,7 +11,7 @@ pub static ENCLAVE_DIR: &'static str = ".enigma";
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     // Create a folder for storage (Sealed, token, etc)
-    // If a storage folder is inaccessible, enclave cannot seal info
+    // If the storage folder is inaccessible, the enclave would not be able to seal info
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);

--- a/enigma-core/app/src/esgx/general.rs
+++ b/enigma-core/app/src/esgx/general.rs
@@ -9,8 +9,8 @@ pub static ENCLAVE_DIR: &'static str = ".enigma";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Create a storage folder for storage (Sealed, etc)
-    // If a storage folder is inaccessible, enclave cannot seal info
+    // Create a folder for storage (Sealed, etc)
+    // If the storage folder is inaccessible, the enclave would not be able to seal info
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
 

--- a/enigma-core/app/src/esgx/general.rs
+++ b/enigma-core/app/src/esgx/general.rs
@@ -10,7 +10,7 @@ pub static ENCLAVE_DIR: &'static str = ".enigma";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Create a storage folder for storage (Sealed, token, etc)
+    // Create a folder for storage (Sealed, token, etc)
     // If a storage folder is inaccessible, enclave cannot seal info
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();

--- a/enigma-core/app/src/esgx/general.rs
+++ b/enigma-core/app/src/esgx/general.rs
@@ -1,20 +1,18 @@
 use enigma_tools_u::{self, esgx::general::storage_dir};
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
-use std::{fs, path};
+use std::fs;
 use log;
 
 static ENCLAVE_FILE: &'static str = "../bin/enclave.signed.so";
-static ENCLAVE_TOKEN: &'static str = "enclave.token";
 pub static ENCLAVE_DIR: &'static str = ".enigma";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Create a storage folder for storage (Sealed, token, etc)
+    // Create a storage folder for storage (Sealed, etc)
     // If a storage folder is inaccessible, enclave cannot seal info
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
-    let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);
 
-    enigma_tools_u::esgx::init_enclave(&token_file, &ENCLAVE_FILE)
+    enigma_tools_u::esgx::init_enclave(&ENCLAVE_FILE)
 }

--- a/enigma-core/app/src/esgx/general.rs
+++ b/enigma-core/app/src/esgx/general.rs
@@ -13,7 +13,7 @@ pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     // Create a folder for storage (Sealed, token, etc)
     // If the storage folder is inaccessible, the enclave would not be able to seal info
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
-    fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
+    fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create the storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);
 
     enigma_tools_u::esgx::init_enclave(&token_file, &ENCLAVE_FILE)

--- a/enigma-core/app/src/esgx/ocalls_u.rs
+++ b/enigma-core/app/src/esgx/ocalls_u.rs
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn ocall_update_state(db_ptr: *const RawPointer, id: &Cont
     match db.force_update(&key, encrypted_state) {
         Ok(_) => EnclaveReturn::Success,
         Err(e) => {
-            println!("Failed creating key in db: {:?} with: \"{}\" ", &key, &e);
+            error!("Failed creating key in db: {:?} with: \"{}\" ", &key, &e);
             EnclaveReturn::OcallDBError
         }
     }
@@ -187,7 +187,6 @@ pub unsafe extern "C" fn ocall_get_deltas(db_ptr: *const RawPointer, addr: &Cont
                     ResultType::None => EnclaveReturn::OcallDBError,
                     ResultType::Full(deltas) | ResultType::Partial(deltas) => {
                         let res = deltas.iter().map(|(_, val)| val.clone()).flatten().collect::<Vec<u8>>();
-                        println!("res: {:?}", res);
                         enigma_types::write_ptr(&res[..], res_ptr, res_len);
                         EnclaveReturn::Success
                     }

--- a/enigma-core/app/src/lib.rs
+++ b/enigma-core/app/src/lib.rs
@@ -1,7 +1,6 @@
 #![warn(clippy::all)]
 #![warn(unused_extern_crates)]
 
-extern crate dirs;
 pub extern crate rocksdb;
 pub extern crate sgx_types;
 extern crate sgx_urts;

--- a/enigma-core/app/src/lib.rs
+++ b/enigma-core/app/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::all)]
 #![warn(unused_extern_crates)]
 
+extern crate dirs;
 pub extern crate rocksdb;
 pub extern crate sgx_types;
 extern crate sgx_urts;

--- a/enigma-core/app/src/main.rs
+++ b/enigma-core/app/src/main.rs
@@ -1,4 +1,5 @@
 extern crate enigma_core_app;
+#[macro_use]
 extern crate log;
 extern crate log_derive;
 
@@ -33,9 +34,9 @@ fn main() {
     debug!("CLI params: {:?}", opt);
 
 
-    let enclave = esgx::general::init_enclave_wrapper().expect("Init Enclave Failed");
+    let enclave = esgx::general::init_enclave_wrapper().map_err(|e| {error!("Init Enclave Failed {:?}", e);}).unwrap();
     let eid = enclave.geteid();
-    info!("[+] Init Enclave Successful {}!", eid);
+    info!("Init Enclave Successful. Enclave id {}", eid);
 
     let mut db = DB::new(datadir, true).expect("Failed initializing the DB");
     let server = IpcListener::new(&format!("tcp://*:{}", opt.port));

--- a/enigma-core/app/src/networking/ipc_listener.rs
+++ b/enigma-core/app/src/networking/ipc_listener.rs
@@ -388,7 +388,6 @@ pub(self) mod handling {
         Ok(IpcResponse::PTTResponse {result})
     }
 
-    #[logfn(TRACE)]
     pub fn deploy_contract(db: &mut DB, input: IpcTask, eid: sgx_enclave_id_t) -> ResponseResult {
         let bytecode = input.pre_code.expect("Bytecode Missing");
         let contract_address = ContractAddress::from_hex(&input.address)?;
@@ -412,13 +411,12 @@ pub(self) mod handling {
                 let key = DeltaKey::new(contract_address, Stype::ByteCode);
                 db.create(&key, &v.output)?;
                 let ipc_response = v.into_deploy_response(&bytecode);
-                info!("deploy_contract() => Ok({})", ipc_response.display_without_bytecode());
-                trace!("deployed bytecode => {}", ipc_response.display_bytecode());
+                debug!("deploy_contract() => Ok({})", ipc_response.display_without_bytecode());
                 Ok(ipc_response)
             },
             WasmResult::WasmTaskFailure(v) => {
                 let response = Ok(v.into());
-                info!("{:?}", response);
+                debug!("{:?}", response);
                 response
             }
         }

--- a/enigma-core/enclave/src/lib.rs
+++ b/enigma-core/enclave/src/lib.rs
@@ -132,7 +132,7 @@ pub unsafe extern "C" fn ecall_execute(
         result,
     );
     if let Err(e) = &internal_result {
-        println!("Error in execution of secret contract function: {}", e);
+        debug_println!("Error in execution of secret contract function: {}", e);
         internal_result = output_task_failure(&pre_execution_data, *gas_limit, e, result, &io_key);
     }
     internal_result.into()
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn ecall_deploy(
         result,
     );
     if let Err(e) = &internal_result {
-        println!("Error in deployment of secret contract function: {}", e);
+        debug_println!("Error in deployment of secret contract function: {}", e);
         internal_result = output_task_failure(&pre_execution_data, *gas_limit, e, result, &io_key);
     }
     internal_result.into()

--- a/enigma-core/enclave/src/lib.rs
+++ b/enigma-core/enclave/src/lib.rs
@@ -121,7 +121,7 @@ pub unsafe extern "C" fn ecall_execute(
         result,
     );
     if let Err(e) = &internal_result {
-        println!("Error in execution of secret contract function: {}", e);
+        debug_println!("Error in execution of secret contract function: {}", e);
         internal_result = output_task_failure(&pre_execution_data, *gas_limit, e, result, &io_key);
     }
     internal_result.into()
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn ecall_deploy(
         result,
     );
     if let Err(e) = &internal_result {
-        println!("Error in deployment of secret contract function: {}", e);
+        debug_println!("Error in deployment of secret contract function: {}", e);
         internal_result = output_task_failure(&pre_execution_data, *gas_limit, e, result, &io_key);
     }
     internal_result.into()

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -1,8 +1,7 @@
-use dirs;
 use enigma_tools_u::{self, esgx::general::storage_dir};
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
-use std::{fs, io::Write, path};
+use std::{fs, path};
 
 static ENCLAVE_FILE: &'static str = "../bin/enclave.signed.so";
 static ENCLAVE_TOKEN: &'static str = "enclave.token";
@@ -13,67 +12,16 @@ pub static STATE_KEYS_DIR: &'static str = "state-keys";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Step 1: try to retrieve the launch token saved by last transaction
-    //         if there is no token, then create a new one.
-    //
-    // try to get the token saved in $HOME */
-    // let mut home_dir = path::PathBuf::new();
-    let use_token = match dirs::home_dir() {
-        Some(path) => {
-            println!("[+] Home dir is {}", path.display());
-            // home_dir = path;
-            true
-        }
-        None => {
-            println!("[-] Cannot get home dir");
-            false
-        }
-    };
-
-    // Step : try to create a .enigma folder for storing all the files
-    // Create a directory, returns `io::Result<()>`
-    // let storage_path = home_dir.join(ENCLAVE_DIR);
+    // Create a storage folders for storage (Sealed info, token, etc)
+    // If a storage folder is inaccessible, km has wrong functionality
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
-    match fs::create_dir(&storage_path) {
-        Err(why) => {
-            println!("[-] Create .enigma folder => {:?}", why.kind());
-        }
-        Ok(_) => {
-            println!("[+] Created new .enigma folder => {:?}", storage_path);
-        }
-    };
-    match fs::create_dir(&storage_path.join(EPOCH_DIR)) {
-        Err(why) => {
-            println!("[-] Create .enigma/epoch folder => {:?}", why.kind());
-        }
-        Ok(_) => {
-            println!("[+] Created new .enigma/epoch folder => {:?}", storage_path);
-        }
-    };
-    match fs::create_dir(&storage_path.join(STATE_KEYS_DIR)) {
-        Err(why) => {
-            println!("[-] Create .enigma/state-keys folder => {:?}", why.kind());
-        }
-        Ok(_) => {
-            println!("[+] Created new .enigma/state-keys folder => {:?}", storage_path);
-        }
-    };
-    // Create the home/dir/.enigma folder for storage (Sealed, token , etc )
+    fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
+    let epoch_storage_path = storage_path.join(EPOCH_DIR);
+    fs::create_dir_all(&epoch_storage_path).map_err(|e| { format_err!("Unable to create epoch storage directory {}: {}", epoch_storage_path.display(), e) }).unwrap();
+    let state_storage_path = storage_path.join(STATE_KEYS_DIR);
+    fs::create_dir_all(&state_storage_path).map_err(|e| { format_err!("Unable to create state storage directory {}: {}", state_storage_path.display(), e) }).unwrap();
+
     let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);
 
-    let (enclave, launch_token) = enigma_tools_u::esgx::init_enclave(&token_file, use_token, &ENCLAVE_FILE)?;
-    // Step 3: save the launch token if it is updated
-    if use_token && launch_token.is_some() {
-        // reopen the file with write capability
-        match fs::File::create(&token_file) {
-            Ok(mut f) => match f.write_all(&launch_token.unwrap()) {
-                Ok(_) => println!("[+] Saved updated launch token!"),
-                Err(_) => println!("[-] Failed to save updated launch token!"),
-            },
-            Err(_) => {
-                println!("[-] Failed to save updated enclave token, but doesn't matter");
-            }
-        }
-    }
-    Ok(enclave)
+    enigma_tools_u::esgx::init_enclave(&token_file, &ENCLAVE_FILE)
 }

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -15,7 +15,7 @@ pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     // Create folders for storage (Sealed info, token, etc)
     // If the storage folder is inaccessible, KM wouldn't operate properly
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
-    fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
+    fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create the storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let epoch_storage_path = storage_path.join(EPOCH_DIR);
     fs::create_dir_all(&epoch_storage_path).map_err(|e| { format_err!("Unable to create epoch storage directory {}: {}", epoch_storage_path.display(), e) }).unwrap();
     let state_storage_path = storage_path.join(STATE_KEYS_DIR);

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -19,7 +19,7 @@ pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     let epoch_storage_path = storage_path.join(EPOCH_DIR);
     fs::create_dir_all(&epoch_storage_path).map_err(|e| { format_err!("Unable to create the epoch storage directory {}: {}", epoch_storage_path.display(), e) }).unwrap();
     let state_storage_path = storage_path.join(STATE_KEYS_DIR);
-    fs::create_dir_all(&state_storage_path).map_err(|e| { format_err!("Unable to create state storage directory {}: {}", state_storage_path.display(), e) }).unwrap();
+    fs::create_dir_all(&state_storage_path).map_err(|e| { format_err!("Unable to create the state storage directory {}: {}", state_storage_path.display(), e) }).unwrap();
 
     let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);
 

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -12,7 +12,7 @@ pub static STATE_KEYS_DIR: &'static str = "state-keys";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Create a storage folders for storage (Sealed info, token, etc)
+    // Create folders for storage (Sealed info, token, etc)
     // If a storage folder is inaccessible, km has wrong functionality
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -11,8 +11,8 @@ pub static STATE_KEYS_DIR: &'static str = "state-keys";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Create a storage folders for storage (Sealed info, epoch, etc)
-    // If a storage folder is inaccessible, km has wrong functionality
+    // Create folders for storage (Sealed info, epoch, etc)
+    // If the storage folders are inaccessible, km wouldn't operate properly
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create the storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let epoch_storage_path = storage_path.join(EPOCH_DIR);

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -4,7 +4,6 @@ use sgx_urts::SgxEnclave;
 use std::{fs, path};
 
 static ENCLAVE_FILE: &'static str = "../bin/enclave.signed.so";
-static ENCLAVE_TOKEN: &'static str = "enclave.token";
 pub static ENCLAVE_DIR: &'static str = ".enigma";
 pub static EPOCH_DIR: &'static str = "epoch";
 pub static EPOCH_FILE: &'static str = "epoch-state.msgpack";
@@ -12,7 +11,7 @@ pub static STATE_KEYS_DIR: &'static str = "state-keys";
 
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
-    // Create a storage folders for storage (Sealed info, token, etc)
+    // Create a storage folders for storage (Sealed info, epoch, etc)
     // If a storage folder is inaccessible, km has wrong functionality
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
@@ -21,7 +20,5 @@ pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     let state_storage_path = storage_path.join(STATE_KEYS_DIR);
     fs::create_dir_all(&state_storage_path).map_err(|e| { format_err!("Unable to create state storage directory {}: {}", state_storage_path.display(), e) }).unwrap();
 
-    let token_file: path::PathBuf = storage_path.join(ENCLAVE_TOKEN);
-
-    enigma_tools_u::esgx::init_enclave(&token_file, &ENCLAVE_FILE)
+    enigma_tools_u::esgx::init_enclave(&ENCLAVE_FILE)
 }

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -13,7 +13,7 @@ pub static STATE_KEYS_DIR: &'static str = "state-keys";
 #[logfn(INFO)]
 pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     // Create folders for storage (Sealed info, token, etc)
-    // If a storage folder is inaccessible, km has wrong functionality
+    // If the storage folder is inaccessible, KM wouldn't operate properly
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let epoch_storage_path = storage_path.join(EPOCH_DIR);

--- a/enigma-principal/app/src/esgx/general.rs
+++ b/enigma-principal/app/src/esgx/general.rs
@@ -17,7 +17,7 @@ pub fn init_enclave_wrapper() -> SgxResult<SgxEnclave> {
     let storage_path = storage_dir(ENCLAVE_DIR).unwrap();
     fs::create_dir_all(&storage_path).map_err(|e| { format_err!("Unable to create the storage directory {}: {}", storage_path.display(), e) }).unwrap();
     let epoch_storage_path = storage_path.join(EPOCH_DIR);
-    fs::create_dir_all(&epoch_storage_path).map_err(|e| { format_err!("Unable to create epoch storage directory {}: {}", epoch_storage_path.display(), e) }).unwrap();
+    fs::create_dir_all(&epoch_storage_path).map_err(|e| { format_err!("Unable to create the epoch storage directory {}: {}", epoch_storage_path.display(), e) }).unwrap();
     let state_storage_path = storage_path.join(STATE_KEYS_DIR);
     fs::create_dir_all(&state_storage_path).map_err(|e| { format_err!("Unable to create state storage directory {}: {}", state_storage_path.display(), e) }).unwrap();
 

--- a/enigma-principal/app/src/main.rs
+++ b/enigma-principal/app/src/main.rs
@@ -63,10 +63,10 @@ fn main() {
 
     debug!("CLI params: {:?}", opt);
 
-    let enclave = esgx::general::init_enclave_wrapper().expect("[-] Init Enclave Failed");
+    let enclave = esgx::general::init_enclave_wrapper().map_err(|e| {error!("Init Enclave Failed {:?}", e);}).unwrap();
     let eid = enclave.geteid();
     cli::app::start(eid).unwrap();
-    info!("[+] Init Enclave Successful {}!", eid);
+    info!("Init Enclave Successful. Enclave id {}", eid);
 
     // drop enclave when done
     enclave.destroy();

--- a/enigma-principal/app/src/main.rs
+++ b/enigma-principal/app/src/main.rs
@@ -63,10 +63,10 @@ fn main() {
 
     debug!("CLI params: {:?}", opt);
 
-    let enclave = esgx::general::init_enclave_wrapper().map_err(|e| {error!("Init Enclave Failed {:?}", e);}).unwrap();
+    let enclave = esgx::general::init_enclave_wrapper().expect("[-] Init Enclave Failed");
     let eid = enclave.geteid();
     cli::app::start(eid).unwrap();
-    info!("Init Enclave Successful. Enclave id {}", eid);
+    info!("[+] Init Enclave Successful {}!", eid);
 
     // drop enclave when done
     enclave.destroy();

--- a/enigma-tools-u/src/esgx/general.rs
+++ b/enigma-tools-u/src/esgx/general.rs
@@ -1,6 +1,5 @@
 use sgx_types::{sgx_attributes_t, sgx_launch_token_t, sgx_misc_attribute_t, SgxResult};
 use sgx_urts::SgxEnclave;
-use std::{fs, io::Read, path, io::Write};
 use std::path::{PathBuf, Path};
 use failure::Error;
 
@@ -13,42 +12,18 @@ pub fn storage_dir<P: AsRef<Path>>(dir_name: P) -> Result<PathBuf, Error> {
     Ok(path)
 }
 
-pub fn init_enclave(token_path: &path::PathBuf, enclave_location: &str)
+pub fn init_enclave(enclave_location: &str)
     -> SgxResult<(SgxEnclave)> {
     let mut launch_token: sgx_launch_token_t = [0; 1024];
     let mut launch_token_updated: i32 = 0;
-
-    match fs::File::open(&token_path) {
-        Err(e) => {
-            match e.kind() {
-                std::io::ErrorKind::NotFound => info!("Enclave launch token does not exist. Will create one."),
-                _ => warn!("Cannot open enclave launch token file: {}.", e)
-            }
-        },
-        Ok(mut f) => {
-            match f.read(&mut launch_token) {
-                Ok(1024) => info!("Enclave launch token found."),
-                _ => warn!("Enclave launch token invalid, will create a new one."),
-            }
-        }
-    }
 
     // Call sgx_create_enclave to initialize an enclave instance
     // Debug Support: set 2nd parameter to 1
     let debug = 1;
     let mut misc_attr = sgx_misc_attribute_t { secs_attr: sgx_attributes_t { flags: 0, xfrm: 0 }, misc_select: 0 };
-    let enclave = SgxEnclave::create(enclave_location, debug, &mut launch_token, &mut launch_token_updated, &mut misc_attr)?;
 
-    if launch_token_updated != 0 {
-        // Save the launch token if it is updated
-        match fs::File::create(&token_path) {
-            Ok(mut f) => match f.write_all(&launch_token) {
-                Ok(_) => info!("Saved updated enclave launch token"),
-                Err(e) => warn!("Failed to save updated enclave launch token: {}", e),
-            },
-            Err(e) => warn!("Failed to save updated enclave launch token: {}", e)
-        }
-        info!("Enclave launch token was updated");
-    }
+    // `launch_token` and `launch_token_updated` are deprecated according to https://download.01.org/intel-sgx/linux-2.6/docs/Intel_SGX_Developer_Reference_Linux_2.6_Open_Source.pdf
+    // see https://github.com/apache/incubator-teaclave-sgx-sdk/pull/163
+    let enclave = SgxEnclave::create(enclave_location, debug, &mut launch_token, &mut launch_token_updated, &mut misc_attr)?;
     Ok(enclave)
 }

--- a/enigma-tools-u/src/esgx/general.rs
+++ b/enigma-tools-u/src/esgx/general.rs
@@ -1,52 +1,54 @@
 use sgx_types::{sgx_attributes_t, sgx_launch_token_t, sgx_misc_attribute_t, SgxResult};
 use sgx_urts::SgxEnclave;
-use std::env;
-use std::fs;
-use std::io::Read;
-use std::path::{self, PathBuf, Path};
-use dirs;
+use std::{fs, io::Read, path, io::Write};
+use std::path::{PathBuf, Path};
 use failure::Error;
 
 pub fn storage_dir<P: AsRef<Path>>(dir_name: P) -> Result<PathBuf, Error> {
-    let mut path = dirs::home_dir().ok_or_else(|| format_err!("Missing HomeDir"))?;
+    let mut path = dirs::home_dir().ok_or_else(|| {
+        format_err!("Missing home directory")
+    })?;
     trace!("Home dir is {}", path.display());
     path.push(dir_name);
     Ok(path)
 }
 
-pub fn init_enclave(token_path: &path::PathBuf, use_token: bool, enclave_location: &str)
-    -> SgxResult<(SgxEnclave, Option<sgx_launch_token_t>)> {
-    let path = env::current_dir().unwrap();
-    trace!("The current directory is {}", path.display());
+pub fn init_enclave(token_path: &path::PathBuf, enclave_location: &str)
+    -> SgxResult<(SgxEnclave)> {
     let mut launch_token: sgx_launch_token_t = [0; 1024];
     let mut launch_token_updated: i32 = 0;
 
-    if use_token {
-        match fs::File::open(&token_path) {
-            Err(_) => {
-                error!("Open token file {} error! Will create one.", token_path.as_path().to_str().unwrap());
+    match fs::File::open(&token_path) {
+        Err(e) => {
+            match e.kind() {
+                std::io::ErrorKind::NotFound => info!("Enclave launch token does not exist. Will create one."),
+                _ => warn!("Cannot open enclave launch token file: {}.", e)
             }
-            Ok(mut f) => {
-                info!("Open token file success! ");
-                match f.read(&mut launch_token) {
-                    Ok(1024) => {
-                        info!("Token file valid!");
-                    }
-                    _ => warn!("Token file invalid, will create new token file"),
-                }
+        },
+        Ok(mut f) => {
+            match f.read(&mut launch_token) {
+                Ok(1024) => info!("Enclave launch token found."),
+                _ => warn!("Enclave launch token invalid, will create a new one."),
             }
         }
     }
 
-    // Step 2: call sgx_create_enclave to initialize an enclave instance
+    // Call sgx_create_enclave to initialize an enclave instance
     // Debug Support: set 2nd parameter to 1
     let debug = 1;
     let mut misc_attr = sgx_misc_attribute_t { secs_attr: sgx_attributes_t { flags: 0, xfrm: 0 }, misc_select: 0 };
     let enclave = SgxEnclave::create(enclave_location, debug, &mut launch_token, &mut launch_token_updated, &mut misc_attr)?;
 
     if launch_token_updated != 0 {
-        info!("Enclave created, Token: {:?}", enclave);
-        return Ok((enclave, Some(launch_token)));
+        // Save the launch token if it is updated
+        match fs::File::create(&token_path) {
+            Ok(mut f) => match f.write_all(&launch_token) {
+                Ok(_) => info!("Saved updated enclave launch token"),
+                Err(e) => warn!("Failed to save updated enclave launch token: {}", e),
+            },
+            Err(e) => warn!("Failed to save updated enclave launch token: {}", e)
+        }
+        info!("Enclave launch token was updated");
     }
-    Ok((enclave, None))
+    Ok(enclave)
 }

--- a/enigma-tools-u/src/lib.rs
+++ b/enigma-tools-u/src/lib.rs
@@ -24,7 +24,6 @@ extern crate log4rs;
 
 #[macro_use]
 extern crate log_derive;
-extern crate dirs;
 extern crate ethabi;
 extern crate ethereum_types;
 extern crate tiny_keccak;


### PR DESCRIPTION
This PR contains:
- moving `println!` to `debug_println!` in core
-  improvement of process and logs in enclave init of core and km
- removing bytecode from log messages