### PR TITLE
MAINT: max_epochs=0

### DIFF
--- a/enigma-principal/app/src/boot_network/config.json
+++ b/enigma-principal/app/src/boot_network/config.json
@@ -9,7 +9,7 @@
     "url": "http://localhost:9545",
     "epoch_size": 10,
     "polling_interval": 1,
-    "max_epochs": 10,
+    "max_epochs": 0,
     "spid": "B0335FD3BC1CCA8F804EB98A6420592D",
     "attestation_service_url": "https://sgx.enigma.co/api",
     "http_port": 3040,

--- a/enigma-principal/app/tests/principal_node/config/principal_test_config.json
+++ b/enigma-principal/app/tests/principal_node/config/principal_test_config.json
@@ -9,7 +9,7 @@
     "url": "http://localhost:9545",
     "epoch_size": 10,
     "polling_interval": 1,
-    "max_epochs": 10,
+    "max_epochs": 0,
     "spid": "B0335FD3BC1CCA8F804EB98A6420592D",
     "attestation_service_url": "https://sgx.enigma.co/api",
     "attestation_retries": 10,

--- a/enigma-principal/app/tests/principal_node/contracts/principal_test_config.json
+++ b/enigma-principal/app/tests/principal_node/contracts/principal_test_config.json
@@ -9,7 +9,7 @@
     "url": "http://localhost:8545",
     "epoch_size": 2,
     "polling_interval": 1,
-    "max_epochs": 10,
+    "max_epochs": 0,
     "spid": "B0335FD3BC1CCA8F804EB98A6420592D",
     "attestation_service_url": "https://sgx.enigma.co/api"
 }


### PR DESCRIPTION
CIs started picking up `max_epochs=10` from the default config, so this PR resets it to `0`