### PR TITLE
MAINT: master is no different in merging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -117,10 +117,7 @@ steps:
         declare -A PROJECT_BRANCH_FOUND=([contract]=$MATCHING_BRANCH_CONTRACT [client]=$MATCHING_BRANCH_INTEGRATION)
         for project in $${PROJECTS[@]}; do
           DOCKER_IMAGE="enigmampc/$${DOCKER_IMAGES[$project]}"
-          if [[ "$DRONE_BRANCH" == "master" ]]; then
-            docker pull "$DOCKER_IMAGE:latest"
-            docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$DOCKER_TAG"
-          elif [ "$${PROJECT_BRANCH_FOUND[$project]}" -eq 0 ]; then
+          if [ "$${PROJECT_BRANCH_FOUND[$project]}" -eq 0 ]; then
             docker pull "$DOCKER_IMAGE:develop"
             docker tag "$DOCKER_IMAGE:develop" "$DOCKER_IMAGE:$DOCKER_TAG"
           else


### PR DESCRIPTION
Adjusted `.drone.yml` so that merges to `master` don't pull existing docker images, but rather behave like merges to `develop` in that all branches build against each other.

When building the images in the `deploy` stage, the distinction is already made to tag them `latest` or `develop` depending on whether the merge is to `master` or `develop` respectively.

Analogous to:
enigmampc/enigma-contract#206
enigmampc/enigma-p2p#311